### PR TITLE
feat: Block password management for users authenticated via external …

### DIFF
--- a/API/Controllers/AccountController.cs
+++ b/API/Controllers/AccountController.cs
@@ -263,6 +263,13 @@ public class AccountController(
 
         if (user == null) return Unauthorized();
 
+        var hasPassword = await signInManager.UserManager.HasPasswordAsync(user);
+
+        if (!hasPassword)
+        {
+            return BadRequest("Password change is not available for users authenticated through external providers. Please manage your password through your authentication provider.");
+        }
+
         var result = await signInManager.UserManager
             .ChangePasswordAsync(user, passwordDto.CurrentPassword, passwordDto.NewPassword);
 

--- a/client/src/app/layout/UserMenu.tsx
+++ b/client/src/app/layout/UserMenu.tsx
@@ -62,16 +62,18 @@ export default function UserMenu() {
           </ListItemIcon>
           <ListItemText>My profile</ListItemText>
         </MenuItem>
-        <MenuItem
-          component={Link}
-          to={"/change-password"}
-          onClick={handleClose}
-        >
-          <ListItemIcon>
-            <Password />
-          </ListItemIcon>
-          <ListItemText>Change password</ListItemText>
-        </MenuItem>
+        {currentUser?.hasPassword && (
+          <MenuItem
+            component={Link}
+            to={"/change-password"}
+            onClick={handleClose}
+          >
+            <ListItemIcon>
+              <Password />
+            </ListItemIcon>
+            <ListItemText>Change password</ListItemText>
+          </MenuItem>
+        )}
         <Divider />
         <MenuItem
           onClick={() => {

--- a/client/src/app/router/RequireAuth.tsx
+++ b/client/src/app/router/RequireAuth.tsx
@@ -1,13 +1,35 @@
 import { Navigate, Outlet, useLocation } from "react-router";
 import { useAccount } from "../../lib/hooks/useAccount";
 import { Typography } from "@mui/material";
+import { useEffect } from "react";
+import { toast } from "react-toastify";
 
 export default function RequireAuth() {
   const { currentUser, loadingUserInfo } = useAccount();
   const location = useLocation();
 
+  useEffect(() => {
+    if (
+      currentUser &&
+      !currentUser.hasPassword &&
+      location.pathname === "/change-password"
+    ) {
+      toast.info(
+        "Password management is handled by your external authentication provider"
+      );
+    }
+  }, [currentUser, location.pathname]);
+
   if (loadingUserInfo) return <Typography>Loading...</Typography>;
   if (!currentUser) return <Navigate to="/login" state={{ from: location }} />;
+
+  if (
+    currentUser &&
+    !currentUser.hasPassword &&
+    location.pathname === "/change-password"
+  ) {
+    return <Navigate to="/chat-rooms" replace />;
+  }
 
   return <Outlet />;
 }

--- a/client/src/features/account/ChangePasswordForm.tsx
+++ b/client/src/features/account/ChangePasswordForm.tsx
@@ -8,9 +8,67 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import TextInput from "../../app/shared/components/TextInput";
 import { useAccount } from "../../lib/hooks/useAccount";
 import { toast } from "react-toastify";
+import { Box, Button, Paper, Typography } from "@mui/material";
+import { Link } from "react-router";
 
 export default function ChangePasswordForm() {
-  const { changePassword } = useAccount();
+  const { changePassword, currentUser } = useAccount();
+
+  if (currentUser && !currentUser.hasPassword) {
+    return (
+      <Paper
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          p: 3,
+          gap: 3,
+          maxWidth: "md",
+          mx: "auto",
+          borderRadius: 3,
+        }}
+      >
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          gap={3}
+          color="secondary.main"
+        >
+          <Password fontSize="large" />
+          <Typography variant="h4">Change Password</Typography>
+        </Box>
+
+        <Box textAlign="center">
+          <Typography variant="h6" color="text.secondary" gutterBottom>
+            Password Not Available
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 3 }}>
+            You are signed in through an external authentication provider.
+            <br />
+            Password changes must be managed through your authentication
+            provider.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Please visit your authentication provider's website to manage your
+            account security.
+          </Typography>
+        </Box>
+
+        <Box textAlign="center">
+          <Button
+            component={Link}
+            to="/chat-rooms"
+            variant="contained"
+            color="primary"
+            sx={{ textDecoration: "none" }}
+          >
+            Return to Chat Rooms
+          </Button>
+        </Box>
+      </Paper>
+    );
+  }
+
   const onSubmit = async (data: ChangePasswordSchema) => {
     try {
       await changePassword.mutateAsync(data, {

--- a/client/src/lib/types/index.d.ts
+++ b/client/src/lib/types/index.d.ts
@@ -14,6 +14,7 @@ export type User = {
   email: string;
   displayName: string;
   imageUrl?: string;
+  hasPassword: boolean;
 };
 
 export type ChatRoom = {


### PR DESCRIPTION
This pull request introduces changes to handle scenarios where users authenticated through external providers cannot change their passwords within the application. It ensures a clear user experience by displaying appropriate messages and restricting access to the password change functionality for such users.

### Backend Changes:
* **Validation for password change**: Added a check in `ChangePassword` API to prevent password changes for users authenticated via external providers, returning an appropriate error message. (`API/Controllers/AccountController.cs`, [API/Controllers/AccountController.csR266-R272](diffhunk://#diff-acd0f988134115c08bdb588219f6fff7e400ab249b35fa5fe02e8547a8b6155fR266-R272))

### Frontend Changes:
* **UI adjustments in `ChangePasswordForm`**:
  - Added a message informing users authenticated through external providers that password changes must be managed externally.
  - Provided a button to navigate back to the chat rooms page. (`client/src/features/account/ChangePasswordForm.tsx`, [client/src/features/account/ChangePasswordForm.tsxR11-R71](diffhunk://#diff-118dd37935d9c8d9ed2a05745b462b4b4006752c2f42f557f82edbb6dec1cfb3R11-R71))
* **Navigation restrictions in `RequireAuth`**:
  - Redirected users without a password away from the `/change-password` route to `/chat-rooms` with a toast notification. (`client/src/app/router/RequireAuth.tsx`, [client/src/app/router/RequireAuth.tsxR4-R33](diffhunk://#diff-e098f88d717a39494f07201cf23b2fdedf786f9012e1415288efd4e3fdef2837R4-R33))
* **Conditional rendering in `UserMenu`**:
  - The "Change password" menu option is now displayed only if the user has a password. (`client/src/app/layout/UserMenu.tsx`, [[1]](diffhunk://#diff-7cb7c1aa0987907700638291306bcdc40e9ba976b45ffaf25f57631b2bcdfc8aR65) [[2]](diffhunk://#diff-7cb7c1aa0987907700638291306bcdc40e9ba976b45ffaf25f57631b2bcdfc8aR76)…providers