### PR TITLE
feat: Remove IsRead and UnreadCount properties from DirectMessage and DirectChat DTOs

### DIFF
--- a/Application/DirectChats/DTOs/DirectChatDto.cs
+++ b/Application/DirectChats/DTOs/DirectChatDto.cs
@@ -9,7 +9,6 @@ public class DirectChatDto
     public DateTime LastMessageAt { get; set; }
     public string? LastMessageBody { get; set; }
     public string? LastMessageSenderId { get; set; }
-    public int UnreadCount { get; set; }
     public bool CanSendMessages { get; set; }
     public bool IsOnline { get; set; }
     public DateTime? LastSeen { get; set; }

--- a/Application/DirectChats/Queries/GetDirectChats.cs
+++ b/Application/DirectChats/Queries/GetDirectChats.cs
@@ -37,8 +37,6 @@ public class GetDirectChats
                     LastMessageAt = dc.LastMessageAt,
                     LastMessageBody = dc.LastMessageBody,
                     LastMessageSenderId = dc.LastMessageSenderId,
-                    UnreadCount = dc.Messages.Count(m =>
-                        m.SenderId != currentUser.Id && !m.IsRead),
                     CanSendMessages = context.UserFriends.Any(uf =>
                         (
                             uf.UserId == currentUser.Id &&

--- a/Application/DirectMessages/DTOs/DirectMessageDto.cs
+++ b/Application/DirectMessages/DTOs/DirectMessageDto.cs
@@ -8,7 +8,6 @@ public class DirectMessageDto
     public required string SenderId { get; set; }
     public required string SenderDisplayName { get; set; }
     public string? SenderImageUrl { get; set; }
-    public bool IsRead { get; set; }
     public bool IsOwnMessage { get; set; }
     public string Type { get; set; } = "Text";
 

--- a/Domain/DirectMessage.cs
+++ b/Domain/DirectMessage.cs
@@ -7,7 +7,6 @@ public class DirectMessage
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public required string Body { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    public bool IsRead { get; set; } = false;
     public MessageType Type { get; set; } = MessageType.Text;
 
     // Media properties

--- a/Persistance/Migrations/20250630095821_RemoveIsReadFromDirectMessages.Designer.cs
+++ b/Persistance/Migrations/20250630095821_RemoveIsReadFromDirectMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Persistance;
 
@@ -11,9 +12,11 @@ using Persistance;
 namespace Persistance.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250630095821_RemoveIsReadFromDirectMessages")]
+    partial class RemoveIsReadFromDirectMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistance/Migrations/20250630095821_RemoveIsReadFromDirectMessages.cs
+++ b/Persistance/Migrations/20250630095821_RemoveIsReadFromDirectMessages.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistance.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveIsReadFromDirectMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsRead",
+                table: "DirectMessages");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRead",
+                table: "DirectMessages",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/client/src/features/directChats/DirectChatList.tsx
+++ b/client/src/features/directChats/DirectChatList.tsx
@@ -7,7 +7,6 @@ import {
   ListItem,
   ListItemAvatar,
   ListItemText,
-  Chip,
   Paper,
 } from "@mui/material";
 import { Link } from "react-router";
@@ -105,13 +104,6 @@ export default function DirectChatsList() {
                         <Box
                           sx={{ display: "flex", gap: 1, alignItems: "center" }}
                         >
-                          {chat.unreadCount > 0 && (
-                            <Chip
-                              label={chat.unreadCount}
-                              color="primary"
-                              size="small"
-                            />
-                          )}
                           <Typography variant="caption" color="text.secondary">
                             {timeAgo(chat.lastMessageAt)}
                           </Typography>

--- a/client/src/lib/types/index.d.ts
+++ b/client/src/lib/types/index.d.ts
@@ -114,7 +114,6 @@ export type DirectChat = {
   lastMessageAt: Date;
   lastMessageBody?: string;
   lastMessageSenderId?: string;
-  unreadCount: number;
   isOnline: boolean;
   canSendMessages: boolean;
   status?: string;
@@ -128,7 +127,6 @@ export type DirectMessage = {
   senderId: string;
   senderDisplayName: string;
   senderImageUrl?: string;
-  isRead: boolean;
   isOwnMessage: boolean;
   type: MessageType;
 


### PR DESCRIPTION
This pull request removes the `IsRead` property from the `DirectMessage` entity and related DTOs, eliminates the `UnreadCount` property from the `DirectChatDto`, and updates the database schema and frontend code accordingly. These changes simplify the data model and UI by removing the tracking of read/unread messages.

### Backend Changes:

* **Removal of `IsRead` Property:**
  - Removed the `IsRead` property from the `DirectMessage` entity in `Domain/DirectMessage.cs`.
  - Removed the `IsRead` property from `DirectMessageDto` in `Application/DirectMessages/DTOs/DirectMessageDto.cs`.

* **Removal of `UnreadCount` Property:**
  - Removed the `UnreadCount` property from `DirectChatDto` in `Application/DirectChats/DTOs/DirectChatDto.cs`.
  - Updated the `GetDirectChats` query to no longer calculate or return the `UnreadCount`.

* **Database Migration:**
  - Added a migration to drop the `IsRead` column from the `DirectMessages` table.
  - Updated the `AppDbContextModelSnapshot` to reflect the removal of the `IsRead` column.

### Frontend Changes:

* **UI Simplification:**
  - Removed the unread message count indicator (`Chip` component) from the `DirectChatList` UI in `client/src/features/directChats/DirectChatList.tsx`.
  - Removed the unused `Chip` import from the same file.