### PR TITLE
feat: add reply functionality to messages and direct messages

### DIFF
--- a/Application/Core/MappingProfiles.cs
+++ b/Application/Core/MappingProfiles.cs
@@ -79,7 +79,12 @@ public class MappingProfiles : Profile
             .ForMember(d => d.MediaPublicId, o => o.MapFrom(s => s.MediaPublicId))
             .ForMember(d => d.MediaType, o => o.MapFrom(s => s.MediaType))
             .ForMember(d => d.MediaFileSize, o => o.MapFrom(s => s.MediaFileSize))
-            .ForMember(d => d.MediaOriginalFileName, o => o.MapFrom(s => s.MediaOriginalFileName));
+            .ForMember(d => d.MediaOriginalFileName, o => o.MapFrom(s => s.MediaOriginalFileName))
+            .ForMember(d => d.ReplyToMessageId, o => o.MapFrom(s => s.ReplyToMessageId))
+            .ForMember(d => d.ReplyToDisplayName, o => o.MapFrom(s => s.ReplyToMessage != null ? s.ReplyToMessage.User.DisplayName : null))
+            .ForMember(d => d.ReplyToBody, o => o.MapFrom(s => s.ReplyToMessage != null ? s.ReplyToMessage.Body : null))
+            .ForMember(d => d.ReplyToType, o => o.MapFrom(s => s.ReplyToMessage != null ? s.ReplyToMessage.Type.ToString() : null))
+            .ForMember(d => d.ReplyToMediaOriginalFileName, o => o.MapFrom(s => s.ReplyToMessage != null ? s.ReplyToMessage.MediaOriginalFileName : null));
 
         CreateMap<DirectChat, DirectChatDto>()
             .ForMember(d => d.OtherUserId, o => o.MapFrom(s =>
@@ -105,7 +110,12 @@ public class MappingProfiles : Profile
             .ForMember(d => d.MediaPublicId, o => o.MapFrom(s => s.MediaPublicId))
             .ForMember(d => d.MediaType, o => o.MapFrom(s => s.MediaType))
             .ForMember(d => d.MediaFileSize, o => o.MapFrom(s => s.MediaFileSize))
-            .ForMember(d => d.MediaOriginalFileName, o => o.MapFrom(s => s.MediaOriginalFileName));
+            .ForMember(d => d.MediaOriginalFileName, o => o.MapFrom(s => s.MediaOriginalFileName))
+            .ForMember(d => d.ReplyToMessageId, o => o.MapFrom(s => s.ReplyToDirectMessageId))
+            .ForMember(d => d.ReplyToDisplayName, o => o.MapFrom(s => s.ReplyToDirectMessage != null ? s.ReplyToDirectMessage.Sender.DisplayName : null))
+            .ForMember(d => d.ReplyToBody, o => o.MapFrom(s => s.ReplyToDirectMessage != null ? s.ReplyToDirectMessage.Body : null))
+            .ForMember(d => d.ReplyToType, o => o.MapFrom(s => s.ReplyToDirectMessage != null ? s.ReplyToDirectMessage.Type.ToString() : null))
+            .ForMember(d => d.ReplyToMediaOriginalFileName, o => o.MapFrom(s => s.ReplyToDirectMessage != null ? s.ReplyToDirectMessage.MediaOriginalFileName : null));
 
         CreateMap<UserFriend, FriendDto>()
             .ForMember(d => d.Id, o => o.MapFrom(s => s.Friend.Id))

--- a/Application/DirectMessages/Commands/SendDirectMessage.cs
+++ b/Application/DirectMessages/Commands/SendDirectMessage.cs
@@ -18,6 +18,8 @@ public class SendDirectMessage
         public required string DirectChatId { get; set; }
         public string Type { get; set; } = "Text";
 
+        public string? ReplyToMessageId { get; set; }
+
         public string? MediaUrl { get; set; }
         public string? MediaPublicId { get; set; }
         public string? MediaType { get; set; }
@@ -72,8 +74,21 @@ public class SendDirectMessage
                 MediaPublicId = request.MediaPublicId,
                 MediaType = request.MediaType,
                 MediaFileSize = request.MediaFileSize,
-                MediaOriginalFileName = request.MediaOriginalFileName
+                MediaOriginalFileName = request.MediaOriginalFileName,
+                ReplyToDirectMessageId = null
             };
+
+            if (!string.IsNullOrEmpty(request.ReplyToMessageId))
+            {
+                var repliedTo = await context.DirectMessages
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(m => m.Id == request.ReplyToMessageId, cancellationToken);
+                if (repliedTo == null || repliedTo.DirectChatId != directChat.Id)
+                {
+                    return Result<DirectMessageDto>.Failure("Invalid replied message", 400);
+                }
+                message.ReplyToDirectMessageId = repliedTo.Id;
+            }
 
             directChat.Messages.Add(message);
             directChat.LastMessageAt = message.CreatedAt;

--- a/Application/DirectMessages/DTOs/DirectMessageDto.cs
+++ b/Application/DirectMessages/DTOs/DirectMessageDto.cs
@@ -16,4 +16,11 @@ public class DirectMessageDto
     public string? MediaType { get; set; }
     public long? MediaFileSize { get; set; }
     public string? MediaOriginalFileName { get; set; }
+
+    // Reply metadata (normalized to same names as chat messages)
+    public string? ReplyToMessageId { get; set; }
+    public string? ReplyToDisplayName { get; set; }
+    public string? ReplyToBody { get; set; }
+    public string? ReplyToType { get; set; }
+    public string? ReplyToMediaOriginalFileName { get; set; }
 }

--- a/Application/Messages/Commands/AddMessage.cs
+++ b/Application/Messages/Commands/AddMessage.cs
@@ -18,6 +18,8 @@ public class AddMessage
         public required string ChatRoomId { get; set; }
         public string Type { get; set; } = "Text";
 
+        public string? ReplyToMessageId { get; set; }
+
         public string? MediaUrl { get; set; }
         public string? MediaPublicId { get; set; }
         public string? MediaType { get; set; }
@@ -58,8 +60,21 @@ public class AddMessage
                 MediaPublicId = request.MediaPublicId,
                 MediaType = request.MediaType,
                 MediaFileSize = request.MediaFileSize,
-                MediaOriginalFileName = request.MediaOriginalFileName
+                MediaOriginalFileName = request.MediaOriginalFileName,
+                ReplyToMessageId = null
             };
+
+            if (!string.IsNullOrEmpty(request.ReplyToMessageId))
+            {
+                var repliedTo = await context.Messages
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(m => m.Id == request.ReplyToMessageId, cancellationToken);
+                if (repliedTo == null || repliedTo.ChatRoomId != chatRoom.Id)
+                {
+                    return Result<MessageDto>.Failure("Invalid replied message", 400);
+                }
+                message.ReplyToMessageId = repliedTo.Id;
+            }
 
             chatRoom.Messages.Add(message);
 

--- a/Application/Messages/DTOs/MessageDto.cs
+++ b/Application/Messages/DTOs/MessageDto.cs
@@ -15,4 +15,11 @@ public class MessageDto
     public string? MediaType { get; set; }
     public long? MediaFileSize { get; set; }
     public string? MediaOriginalFileName { get; set; }
+
+    // Reply metadata
+    public string? ReplyToMessageId { get; set; }
+    public string? ReplyToDisplayName { get; set; }
+    public string? ReplyToBody { get; set; }
+    public string? ReplyToType { get; set; }
+    public string? ReplyToMediaOriginalFileName { get; set; }
 }

--- a/Domain/DirectMessage.cs
+++ b/Domain/DirectMessage.cs
@@ -20,4 +20,8 @@ public class DirectMessage
     public User Sender { get; set; } = null!;
     public required string DirectChatId { get; set; }
     public DirectChat DirectChat { get; set; } = null!;
+
+    // Reply relationship (self-reference)
+    public string? ReplyToDirectMessageId { get; set; }
+    public DirectMessage? ReplyToDirectMessage { get; set; }
 }

--- a/Domain/Message.cs
+++ b/Domain/Message.cs
@@ -20,4 +20,8 @@ public class Message
     public User User { get; set; } = null!;
     public required string ChatRoomId { get; set; }
     public ChatRoom ChatRoom { get; set; } = null!;
+
+    // Reply relationship (self-reference)
+    public string? ReplyToMessageId { get; set; }
+    public Message? ReplyToMessage { get; set; }
 }

--- a/Persistance/AppDbContext.cs
+++ b/Persistance/AppDbContext.cs
@@ -101,7 +101,24 @@ public class AppDbContext(DbContextOptions options) : IdentityDbContext<User>(op
                 .HasForeignKey(dm => dm.DirectChatId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            // Self-referencing reply relationship
+            x.HasOne(dm => dm.ReplyToDirectMessage)
+                .WithMany()
+                .HasForeignKey(dm => dm.ReplyToDirectMessageId)
+                .OnDelete(DeleteBehavior.NoAction);
+
             x.HasIndex(dm => new { dm.DirectChatId, dm.CreatedAt });
+        });
+
+        // Reply relationship for chat room messages
+        builder.Entity<Message>(x =>
+        {
+            x.HasOne(m => m.ReplyToMessage)
+                .WithMany()
+                .HasForeignKey(m => m.ReplyToMessageId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            x.HasIndex(m => new { m.ChatRoomId, m.CreatedAt });
         });
 
         builder.Entity<User>()

--- a/Persistance/Migrations/20250904064722_AddMessageReplies.Designer.cs
+++ b/Persistance/Migrations/20250904064722_AddMessageReplies.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Persistance;
 
@@ -11,9 +12,11 @@ using Persistance;
 namespace Persistance.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904064722_AddMessageReplies")]
+    partial class AddMessageReplies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistance/Migrations/20250904064722_AddMessageReplies.cs
+++ b/Persistance/Migrations/20250904064722_AddMessageReplies.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMessageReplies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Messages_ChatRoomId",
+                table: "Messages");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReplyToMessageId",
+                table: "Messages",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReplyToDirectMessageId",
+                table: "DirectMessages",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Messages_ChatRoomId_CreatedAt",
+                table: "Messages",
+                columns: new[] { "ChatRoomId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Messages_ReplyToMessageId",
+                table: "Messages",
+                column: "ReplyToMessageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DirectMessages_ReplyToDirectMessageId",
+                table: "DirectMessages",
+                column: "ReplyToDirectMessageId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DirectMessages_DirectMessages_ReplyToDirectMessageId",
+                table: "DirectMessages",
+                column: "ReplyToDirectMessageId",
+                principalTable: "DirectMessages",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Messages_Messages_ReplyToMessageId",
+                table: "Messages",
+                column: "ReplyToMessageId",
+                principalTable: "Messages",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DirectMessages_DirectMessages_ReplyToDirectMessageId",
+                table: "DirectMessages");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Messages_Messages_ReplyToMessageId",
+                table: "Messages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Messages_ChatRoomId_CreatedAt",
+                table: "Messages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Messages_ReplyToMessageId",
+                table: "Messages");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DirectMessages_ReplyToDirectMessageId",
+                table: "DirectMessages");
+
+            migrationBuilder.DropColumn(
+                name: "ReplyToMessageId",
+                table: "Messages");
+
+            migrationBuilder.DropColumn(
+                name: "ReplyToDirectMessageId",
+                table: "DirectMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Messages_ChatRoomId",
+                table: "Messages",
+                column: "ChatRoomId");
+        }
+    }
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -898,14 +898,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3084,15 +3097,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, CircularProgress, Chip, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, Chip, Typography, IconButton, Paper } from "@mui/material";
+import { ReplyOutlined } from "@mui/icons-material";
 import { Link } from "react-router";
 import { timeAgo } from "../../../../lib/util/util";
 import MessageAvatarWithStatus from "../MessageAvatarWithStatus";
@@ -14,6 +15,8 @@ interface ChatMessageListProps {
     | React.RefObject<HTMLDivElement>
     | ((node?: Element | null) => void);
   messagesEndRef?: React.RefObject<HTMLDivElement | null>;
+  onReplyClick?: (messageId: string) => void;
+  onJumpToMessage?: (messageId: string) => void;
 }
 
 export default function ChatMessageList({
@@ -23,6 +26,8 @@ export default function ChatMessageList({
   onFileDownload,
   loadMoreRef,
   messagesEndRef,
+  onReplyClick,
+  onJumpToMessage,
 }: ChatMessageListProps) {
   return (
     <>
@@ -55,7 +60,7 @@ export default function ChatMessageList({
 
       {/* Messages list */}
       {messageStore.messages.map((message) => (
-        <Box key={message.id} sx={{ display: "flex", mb: 2 }}>
+        <Box key={message.id} id={`msg-${message.id}`} sx={{ display: "flex", mb: 2 }}>
           <MessageAvatarWithStatus
             userId={message.senderId || message.userId || ""}
             imageUrl={message.senderImageUrl || message.imageUrl}
@@ -89,7 +94,35 @@ export default function ChatMessageList({
                   variant="outlined"
                 />
               )}
+              {onReplyClick && (
+                <IconButton
+                  size="small"
+                  sx={{ ml: "auto" }}
+                  title="Reply"
+                  onClick={() => onReplyClick(message.id)}
+                >
+                  <ReplyOutlined fontSize="small" />
+                </IconButton>
+              )}
             </Box>
+
+            {/* Replied-to preview */}
+            {message.replyToMessageId && (
+              <Paper
+                variant="outlined"
+                sx={{ p: 1, mb: 1, bgcolor: "action.hover", cursor: onJumpToMessage ? "pointer" : "default" }}
+                onClick={() => onJumpToMessage && onJumpToMessage(message.replyToMessageId!)}
+              >
+                <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                  Replying to {message.replyToDisplayName || "message"}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {message.replyToType && message.replyToType !== "Text"
+                    ? `📎 ${message.replyToMediaOriginalFileName || message.replyToType}`
+                    : message.replyToBody || ""}
+                </Typography>
+              </Paper>
+            )}
 
             <MessageContentRenderer
               message={message}

--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Box } from "@mui/material";
+import { Card, CardContent, Box, Typography } from "@mui/material";
 import { useState, useEffect } from "react";
 import { observer } from "mobx-react-lite";
 import { useInView } from "react-intersection-observer";
@@ -25,7 +25,8 @@ interface MediaChatComponentProps {
   onSendMessage: (
     body: string,
     type?: MessageType,
-    mediaData?: Partial<MediaUploadResult>
+    mediaData?: Partial<MediaUploadResult>,
+    replyToMessageId?: string
   ) => Promise<void>;
   showUserProfiles?: boolean;
   chatRoomId?: string;
@@ -48,6 +49,13 @@ const MediaChatComponent = observer(function MediaChatComponent({
     src: null,
   });
   const [showEmojiSettings, setShowEmojiSettings] = useState(false);
+  const [replyToMessageId, setReplyToMessageId] = useState<string | undefined>(undefined);
+  const [replyPreview, setReplyPreview] = useState<{
+    displayName?: string;
+    body?: string;
+    type?: MessageType;
+    mediaOriginalFileName?: string;
+  } | undefined>(undefined);
 
   const chatType = chatRoomId ? "ChatRoom" : "DirectChat";
   const chatId = chatRoomId || directChatId || "";
@@ -58,7 +66,8 @@ const MediaChatComponent = observer(function MediaChatComponent({
   const scrollHandler = useScrollHandler({ messageStore });
   const fileUpload = useFileUpload({
     chatRoomId,
-    onUpload: onSendMessage,
+    onUpload: async (body, type, mediaData) =>
+      onSendMessage(body, type, mediaData, replyToMessageId),
     onReset: () => {}, // Will be called from handleSubmit
   });
 
@@ -95,12 +104,14 @@ const MediaChatComponent = observer(function MediaChatComponent({
 
       const trimmedBody = data.body?.trimEnd();
       if (trimmedBody) {
-        await onSendMessage(trimmedBody);
+        await onSendMessage(trimmedBody, "Text", undefined, replyToMessageId);
       }
     } catch (error) {
       console.error("Send message error:", error);
     } finally {
       scrollHandler.scrollToBottom();
+      setReplyToMessageId(undefined);
+      setReplyPreview(undefined);
     }
   };
 
@@ -132,6 +143,33 @@ const MediaChatComponent = observer(function MediaChatComponent({
   const hasFileAttached = !!(
     fileUpload.pendingPaste.file || fileUpload.selectedFile
   );
+
+  const handleReplyClick = (messageId: string) => {
+    const msg = messageStore.messages.find((m) => m.id === messageId);
+    if (!msg) return;
+    setReplyToMessageId(msg.id);
+    setReplyPreview({
+      displayName: msg.senderDisplayName || msg.displayName,
+      body: msg.body,
+      type: msg.type,
+      mediaOriginalFileName: msg.mediaOriginalFileName,
+    });
+  };
+
+  const handleJumpToMessage = (messageId: string) => {
+    const el = document.getElementById(`msg-${messageId}`);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.animate(
+        [
+          { backgroundColor: "transparent" },
+          { backgroundColor: "rgba(255, 235, 59, 0.3)" },
+          { backgroundColor: "transparent" },
+        ],
+        { duration: 1200 }
+      );
+    }
+  };
 
   return (
     <div {...fileUpload.dropzoneProps}>
@@ -170,11 +208,47 @@ const MediaChatComponent = observer(function MediaChatComponent({
               onFileDownload={handleFileDownload}
               loadMoreRef={loadMoreRef}
               messagesEndRef={scrollHandler.messagesEndRef}
+              onReplyClick={handleReplyClick}
+              onJumpToMessage={handleJumpToMessage}
             />
           </Box>
 
           {/* Message input area */}
           <Box sx={{ p: 2, borderTop: "1px solid", borderColor: "divider" }}>
+            {/* Reply context */}
+            {replyToMessageId && (
+              <Card sx={{ mb: 1, bgcolor: "action.hover" }}>
+                <CardContent sx={{ py: 1.5 }}>
+                  <Box display="flex" alignItems="center" gap={1}>
+                    <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                      Replying to {replyPreview?.displayName}
+                    </Typography>
+                    <Box flexGrow={1} />
+                    <Box
+                      component="button"
+                      onClick={() => {
+                        setReplyToMessageId(undefined);
+                        setReplyPreview(undefined);
+                      }}
+                      sx={{
+                        border: "none",
+                        background: "transparent",
+                        cursor: "pointer",
+                        color: "text.secondary",
+                        fontSize: 12,
+                      }}
+                    >
+                      cancel
+                    </Box>
+                  </Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {replyPreview?.type && replyPreview.type !== "Text"
+                      ? `📎 ${replyPreview?.mediaOriginalFileName || replyPreview?.type}`
+                      : replyPreview?.body}
+                  </Typography>
+                </CardContent>
+              </Card>
+            )}
             {/* File previews */}
             {fileUpload.pendingPaste.file &&
               fileUpload.pendingPaste.preview && (

--- a/client/src/features/chatRooms/details/ChatRoomDetailsChat.tsx
+++ b/client/src/features/chatRooms/details/ChatRoomDetailsChat.tsx
@@ -11,7 +11,8 @@ const ChatRoomDetailsChat = observer(function ChatRoomDetailsChat() {
   const handleSendMessage = async (
     body: string,
     type: MessageType = "Text",
-    mediaData?: Partial<MediaUploadResult>
+    mediaData?: Partial<MediaUploadResult>,
+    replyToMessageId?: string
   ) => {
     const messageData = {
       chatRoomId: id!,
@@ -24,6 +25,7 @@ const ChatRoomDetailsChat = observer(function ChatRoomDetailsChat() {
         mediaFileSize: mediaData.fileSize,
         mediaOriginalFileName: mediaData.originalFileName,
       }),
+      ...(replyToMessageId && { replyToMessageId }),
     };
 
     if (type === "Text") {

--- a/client/src/features/directChats/DirectChatDetails.tsx
+++ b/client/src/features/directChats/DirectChatDetails.tsx
@@ -16,7 +16,8 @@ const DirectChatDetails = observer(function DirectChatDetails() {
   const handleSendMessage = async (
     body: string,
     type: MessageType = "Text",
-    mediaData?: Partial<MediaUploadResult>
+    mediaData?: Partial<MediaUploadResult>,
+    replyToMessageId?: string
   ) => {
     if (!currentChat?.canSendMessages) return;
 
@@ -31,6 +32,7 @@ const DirectChatDetails = observer(function DirectChatDetails() {
         mediaFileSize: mediaData.fileSize,
         mediaOriginalFileName: mediaData.originalFileName,
       }),
+      ...(replyToMessageId && { replyToMessageId }),
     };
 
     if (type === "Text") {

--- a/client/src/lib/types/index.d.ts
+++ b/client/src/lib/types/index.d.ts
@@ -49,6 +49,12 @@ export type BaseMessage = {
   mediaType?: string;
   mediaFileSize?: number;
   mediaOriginalFileName?: string;
+  // Reply metadata (optional, present when this message is a reply)
+  replyToMessageId?: string;
+  replyToDisplayName?: string;
+  replyToBody?: string;
+  replyToType?: MessageType;
+  replyToMediaOriginalFileName?: string;
 };
 
 export type BaseMessageStore = {
@@ -73,6 +79,11 @@ export type ChatMessage = {
   mediaType?: string;
   mediaFileSize?: number;
   mediaOriginalFileName?: string;
+  replyToMessageId?: string;
+  replyToDisplayName?: string;
+  replyToBody?: string;
+  replyToType?: MessageType;
+  replyToMediaOriginalFileName?: string;
 };
 
 export type MessageType = "Text" | "Image" | "Video" | "Document" | "Audio";
@@ -161,6 +172,11 @@ export type DirectMessage = {
   mediaType?: string;
   mediaFileSize?: number;
   mediaOriginalFileName?: string;
+  replyToMessageId?: string;
+  replyToDisplayName?: string;
+  replyToBody?: string;
+  replyToType?: MessageType;
+  replyToMediaOriginalFileName?: string;
 };
 
 export type SendDirectMessageRequest = {
@@ -173,6 +189,7 @@ export type SendDirectMessageRequest = {
   mediaType?: string;
   mediaFileSize?: number;
   mediaOriginalFileName?: string;
+  replyToMessageId?: string;
 };
 
 export type SendMessageRequest = {
@@ -185,6 +202,7 @@ export type SendMessageRequest = {
   mediaType?: string;
   mediaFileSize?: number;
   mediaOriginalFileName?: string;
+  replyToMessageId?: string;
 };
 
 export type SendFriendRequestRequest = {


### PR DESCRIPTION
- Updated MessageDto to include reply metadata fields.
- Enhanced DirectMessage and Message classes with self-referencing reply relationships.
- Modified AppDbContext to establish foreign key relationships for replies.
- Created migration to add reply fields to Messages and DirectMessages tables.
- Updated UI components to support replying to messages, including reply previews.
- Adjusted message sending logic to handle replies.
- Extended type definitions to include reply metadata for messages.