### PR TITLE
feat: Implement chat room access control with permissions and error handling

### DIFF
--- a/API/Controllers/ChatRoomsController.cs
+++ b/API/Controllers/ChatRoomsController.cs
@@ -23,6 +23,7 @@ public class ChatRoomsController : BaseApiController
     }
 
     [HttpGet("{id}")]
+    [Authorize(Policy = ChatRoomPermissions.ViewChatRoom)]
     public async Task<ActionResult<ChatRoomDto>> GetChatRoomDetails(string id)
     {
         return HandleResult(await Mediator.Send(new GetChatRoomDetails.Query { Id = id }));

--- a/API/SignalR/MessageHub.cs
+++ b/API/SignalR/MessageHub.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using Application.Core;
+using Application.Interfaces;
 using Application.Messages.Commands;
 using Application.Messages.Queries;
 using Application.Messages.SignalR;
@@ -9,7 +11,7 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace API.SignalR;
 
-public class MessageHub(IMediator mediator) : Hub
+public class MessageHub(IMediator mediator, IRolePermissionService rolePermissionService) : Hub
 {
     [Authorize(Policy = ChatRoomPermissions.SendMessages)]
     public async Task SendMessage(AddMessage.Command command)
@@ -28,6 +30,7 @@ public class MessageHub(IMediator mediator) : Hub
         }
     }
 
+    [Authorize(Policy = ChatRoomPermissions.SendMessages)]
     public async Task SendMediaMessage(AddMessage.Command command)
     {
         try
@@ -50,6 +53,7 @@ public class MessageHub(IMediator mediator) : Hub
         }
     }
 
+    [Authorize(Policy = ChatRoomPermissions.ViewChatRoom)]
     public async Task LoadMoreMessages(string chatRoomId, DateTime? cursor, int pageSize = 20)
     {
         try
@@ -75,8 +79,23 @@ public class MessageHub(IMediator mediator) : Hub
     {
         var httpContext = Context.GetHttpContext();
         var chatRoomId = httpContext?.Request.Query["chatRoomId"];
-
         if (string.IsNullOrEmpty(chatRoomId)) throw new HubException("No chat room with this id");
+
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
+        {
+            throw new HubException("Unauthenticated user");
+        }
+
+        var hasAccess = await rolePermissionService.HasPermissionAsync(
+            userId!, chatRoomId!, ChatRoomPermissions.ViewChatRoom);
+
+        if (!hasAccess)
+        {
+            await Clients.Caller.SendAsync("ReceiveError", 403, "You are not a member of this chat room");
+            Context.Abort();
+            return;
+        }
 
         await Groups.AddToGroupAsync(Context.ConnectionId, chatRoomId!);
 

--- a/Application/Messages/Commands/AddMessage.cs
+++ b/Application/Messages/Commands/AddMessage.cs
@@ -50,6 +50,13 @@ public class AddMessage
 
             var user = await userAccessor.GetUserAsync();
 
+            // Ensure the user is a member of the chat room
+            var isMember = await context.ChatRoomMembers
+                .AsNoTracking()
+                .AnyAsync(m => m.ChatRoomId == chatRoom.Id && m.UserId == user.Id, cancellationToken);
+            if (!isMember)
+                return Result<MessageDto>.Failure("User is not a member of this chat room", 403);
+
             if (!Enum.TryParse<MessageType>(request.Type, out var messageType))
                 messageType = MessageType.Text;
 

--- a/Domain/Enums/ChatRoomPermissions.cs
+++ b/Domain/Enums/ChatRoomPermissions.cs
@@ -2,6 +2,7 @@ namespace Domain.Enums;
 
 public static class ChatRoomPermissions
 {
+    public const string ViewChatRoom = "View chat room";
     public const string SendMessages = "Send Messages";
     public const string CreateInviteLinks = "Create invite links";
 
@@ -17,6 +18,7 @@ public static class ChatRoomPermissions
     public static readonly Dictionary<string, string> All
         = new()
         {
+            [ViewChatRoom] = "Allows the user to view and access the chat room.",
             [SendMessages] = "Allows the user to send messages in the chat room.",
             [CreateInviteLinks] = "Allows the user to create invite links for the chat room.",
         };

--- a/Domain/Enums/ChatRoomRoles.cs
+++ b/Domain/Enums/ChatRoomRoles.cs
@@ -14,9 +14,11 @@ public class ChatRoomRoles
 
     public static readonly Dictionary<(string role, string permission), bool> DefaultsPermissions = new()
     {
+        [(Moderator, ChatRoomPermissions.ViewChatRoom)] = true,
         [(Moderator, ChatRoomPermissions.SendMessages)] = true,
         [(Moderator, ChatRoomPermissions.CreateInviteLinks)] = true,
 
+        [(Member, ChatRoomPermissions.ViewChatRoom)] = true,
         [(Member, ChatRoomPermissions.SendMessages)] = true,
         [(Member, ChatRoomPermissions.CreateInviteLinks)] = false,
     };

--- a/Infrastructure/Services/RolePermissionService.cs
+++ b/Infrastructure/Services/RolePermissionService.cs
@@ -143,6 +143,13 @@ public class RolePermissionService(AppDbContext context) : IRolePermissionServic
         if (chatRoom?.OwnerId == userId)
             return true;
 
+        // Access to view a chat room is equivalent to being a member
+        if (permissionName == ChatRoomPermissions.ViewChatRoom)
+        {
+            return await context.ChatRoomMembers
+                .AnyAsync(m => m.ChatRoomId == chatRoomId && m.UserId == userId);
+        }
+
         return await context.ChatRoomMemberRoles
             .Where(mr => mr.UserId == userId && mr.ChatRoomId == chatRoomId)
             .SelectMany(mr => mr.Role.RolePermissions)

--- a/client/src/lib/api/agent.ts
+++ b/client/src/lib/api/agent.ts
@@ -33,7 +33,7 @@ agent.interceptors.response.use(
     }
     store.uiStore.isIdle();
 
-    const { status, data } = error.response;
+    const { status, data, config } = error.response;
     switch (status) {
       case 400:
         if (data.errors) {
@@ -55,6 +55,21 @@ agent.interceptors.response.use(
           toast.error("Unauthorised");
         }
         break;
+      case 403: {
+        const isChatRoomDetailsGet =
+          config?.url?.startsWith("/chatRooms/") &&
+          (config?.method ?? "get").toLowerCase() === "get";
+
+        if (isChatRoomDetailsGet) {
+          if (!store.uiStore.consumeSuppressNextChatRoomForbiddenToast()) {
+            toast.error("You are not a member of this chat room");
+            router.navigate("/chat-rooms");
+          }
+        } else {
+          toast.error("Forbidden");
+        }
+        break;
+      }
       case 404:
         router.navigate("/not-found");
         break;

--- a/client/src/lib/hooks/useChatRooms.ts
+++ b/client/src/lib/hooks/useChatRooms.ts
@@ -21,6 +21,7 @@ export const useChatRooms = (id?: string) => {
   const navigate = useNavigate();
   const {
     chatRoomsStore: { filter, startDate },
+    uiStore,
   } = useStore();
 
   const [inviteLink, setInviteLink] = useState<string | null>(null);
@@ -133,7 +134,10 @@ export const useChatRooms = (id?: string) => {
       const { id, ...body } = params;
       setIsGeneratingInvite(true);
       setInviteLink(null);
-      const response = await agent.post<string>(`/chatRooms/${id}/invites`, body);
+      const response = await agent.post<string>(
+        `/chatRooms/${id}/invites`,
+        body
+      );
       return response.data;
     },
     onSuccess: async (data) => {
@@ -169,6 +173,9 @@ export const useChatRooms = (id?: string) => {
   const leaveChatRoom = useMutation({
     mutationFn: async (id: string) => {
       await agent.post(`/chatRooms/${id}/leave`);
+    },
+    onMutate: async () => {
+      uiStore.suppressNextChatRoomForbiddenToast();
     },
     onSuccess: async () => {
       navigate("/chat-rooms");

--- a/client/src/lib/hooks/useMessages.ts
+++ b/client/src/lib/hooks/useMessages.ts
@@ -8,6 +8,7 @@ import { useEffect, useRef } from "react";
 import type { ChatMessage, PagedList } from "../types";
 import { runInAction } from "mobx";
 import { toast } from "react-toastify";
+import { router } from "../../app/router/Routes";
 import { calculatePageSizeForMessages } from "../util/util";
 
 export const useMessages = (chatRoomId?: string) => {
@@ -42,6 +43,15 @@ export const useMessages = (chatRoomId?: string) => {
         .catch((error) =>
           console.log("Error establishing connection: ", error)
         );
+
+      this.hubConnection.onclose((error) => {
+        if (import.meta.env.DEV && error)
+          console.log("Message hub closed:", error);
+        if (error) {
+          toast.error("You are not a member of this chat room");
+          router.navigate("/chat-rooms");
+        }
+      });
 
       this.hubConnection.on(
         "LoadMessages",

--- a/client/src/lib/stores/uiStore.ts
+++ b/client/src/lib/stores/uiStore.ts
@@ -2,6 +2,7 @@ import { makeAutoObservable } from "mobx";
 
 export class UiStore {
   isLoading = false;
+  private _suppressNextChatRoomForbiddenToast = false;
 
   constructor() {
     makeAutoObservable(this);
@@ -13,5 +14,17 @@ export class UiStore {
 
   isIdle() {
     this.isLoading = false;
+  }
+
+  suppressNextChatRoomForbiddenToast() {
+    this._suppressNextChatRoomForbiddenToast = true;
+  }
+
+  consumeSuppressNextChatRoomForbiddenToast(): boolean {
+    if (this._suppressNextChatRoomForbiddenToast) {
+      this._suppressNextChatRoomForbiddenToast = false;
+      return true;
+    }
+    return false;
   }
 }

--- a/client/src/lib/types/chatroomPermissions.ts
+++ b/client/src/lib/types/chatroomPermissions.ts
@@ -3,6 +3,7 @@
  * Check: Domain/Enums/ChatRoomPermissions.cs
  */
 export const CHATROOM_PERMISSIONS = {
+  ViewChatRoom: "View chat room",
   SendMessages: "Send Messages",
   CreateInviteLinks: "Create invite links",
 } as const;


### PR DESCRIPTION
This pull request introduces stricter access control and improved user feedback for chat room membership and permissions across both backend and frontend. The most significant changes include enforcing "view chat room" permissions for SignalR connections and HTTP endpoints, providing clearer error handling and user messaging on forbidden access, and ensuring that only chat room members can send messages or access chat room details.

**Backend: Access Control and Permissions**

* Added a new `ViewChatRoom` permission to `ChatRoomPermissions`, updated default role permissions to include it for members and moderators, and documented its purpose. [[1]](diffhunk://#diff-5ad7bbeb3d37dce07cc12a194f6812c51b0125646deb9cc591dd55d721586972R5) [[2]](diffhunk://#diff-5ad7bbeb3d37dce07cc12a194f6812c51b0125646deb9cc591dd55d721586972R21) [[3]](diffhunk://#diff-ed26fb8f2eea28283c0a1ff57becd28f6c48434bf65f2213204a8e62d24df5fdR17-R21)
* Enforced `ViewChatRoom` permission on SignalR hub connection (`OnConnectedAsync`), message sending methods, and the HTTP GET endpoint for chat room details, aborting connections and returning errors for unauthorized users. [[1]](diffhunk://#diff-a1445ead3e5ca405d1294969d987f70aa3087ce77537fc592fac203a36a83f1aR26) [[2]](diffhunk://#diff-84c2187ab2cd20324e57710196cf2d85b957c9770e5f1de59c85f8fc02dc8a96L12-R14) [[3]](diffhunk://#diff-84c2187ab2cd20324e57710196cf2d85b957c9770e5f1de59c85f8fc02dc8a96L78-R99) [[4]](diffhunk://#diff-84c2187ab2cd20324e57710196cf2d85b957c9770e5f1de59c85f8fc02dc8a96R56)
* Updated message sending command handler to check if the user is a chat room member before allowing message creation.
* Modified `RolePermissionService` to treat chat room membership as sufficient for `ViewChatRoom` permission checks.

**Frontend: User Feedback and Error Handling**

* Enhanced API error handling to display specific forbidden access messages when users try to view chat rooms they are not members of, and redirect them appropriately. [[1]](diffhunk://#diff-e64db02ca41bc3e5a1372249ff67c5d1dade5dd0c9d2261e0031a2e6c5df6c12L36-R36) [[2]](diffhunk://#diff-e64db02ca41bc3e5a1372249ff67c5d1dade5dd0c9d2261e0031a2e6c5df6c12R58-R72)
* Improved SignalR connection error handling in `useMessages` to show a toast and redirect when the hub closes due to forbidden access. [[1]](diffhunk://#diff-c1c4de67f259ec1a01c978c662565830b35c65fb9ff56b9adcb844afab784f8aR11) [[2]](diffhunk://#diff-c1c4de67f259ec1a01c978c662565830b35c65fb9ff56b9adcb844afab784f8aR47-R55)
* Added logic to suppress duplicate forbidden toasts when leaving a chat room and navigating away, using new methods in `UiStore`. [[1]](diffhunk://#diff-02d193b7ce53c78842d696d08475b5dc308a3ee79fa9c8b2d16d485701e16107R5) [[2]](diffhunk://#diff-02d193b7ce53c78842d696d08475b5dc308a3ee79fa9c8b2d16d485701e16107R18-R29) [[3]](diffhunk://#diff-e56f964107231b3a303400fa6dbbee7be07305ff9feea2656387cb1d4f6e1f46R24) [[4]](diffhunk://#diff-e56f964107231b3a303400fa6dbbee7be07305ff9feea2656387cb1d4f6e1f46R177-R179)

**Other**

* Synced frontend permission constants with backend definitions to ensure consistency.