### PR TITLE
Fix bug that resets pagination after user leaves chat page and returns

### DIFF
--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -21,6 +21,9 @@ import EmojiSettingsDialog from "../EmojiSettingsDialog";
 import type { useChatRoomRolesRealtime } from "../../../../lib/hooks/useChatRoomRolesRealtime";
 import { CHATROOM_PERMISSIONS } from "../../../../lib/types/chatroomPermissions";
 
+const MAX_JUMP_ATTEMPTS = 1000;
+const RETRY_DELAY_MS = 100;
+
 interface MediaChatComponentProps {
   title: string;
   messageStore: BaseMessageStore;
@@ -180,7 +183,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
       );
     };
 
-    for (let attempts = 0; attempts < 50; attempts++) {
+    for (let attempts = 0; attempts < MAX_JUMP_ATTEMPTS; attempts++) {
       const el = document.getElementById(
         `msg-${messageId}`
       ) as HTMLElement | null;
@@ -199,7 +202,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
         messageStore.loadOlderMessages();
       }
 
-      await new Promise((res) => setTimeout(res, 150));
+      await new Promise((res) => setTimeout(res, RETRY_DELAY_MS));
     }
   };
 

--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -55,13 +55,18 @@ const MediaChatComponent = observer(function MediaChatComponent({
     src: null,
   });
   const [showEmojiSettings, setShowEmojiSettings] = useState(false);
-  const [replyToMessageId, setReplyToMessageId] = useState<string | undefined>(undefined);
-  const [replyPreview, setReplyPreview] = useState<{
-    displayName?: string;
-    body?: string;
-    type?: MessageType;
-    mediaOriginalFileName?: string;
-  } | undefined>(undefined);
+  const [replyToMessageId, setReplyToMessageId] = useState<string | undefined>(
+    undefined
+  );
+  const [replyPreview, setReplyPreview] = useState<
+    | {
+        displayName?: string;
+        body?: string;
+        type?: MessageType;
+        mediaOriginalFileName?: string;
+      }
+    | undefined
+  >(undefined);
 
   const chatType = chatRoomId ? "ChatRoom" : "DirectChat";
   const chatId = chatRoomId || directChatId || "";
@@ -162,9 +167,8 @@ const MediaChatComponent = observer(function MediaChatComponent({
     });
   };
 
-  const handleJumpToMessage = (messageId: string) => {
-    const el = document.getElementById(`msg-${messageId}`);
-    if (el) {
+  const handleJumpToMessage = async (messageId: string) => {
+    const highlight = (el: HTMLElement) => {
       el.scrollIntoView({ behavior: "smooth", block: "center" });
       el.animate(
         [
@@ -174,6 +178,28 @@ const MediaChatComponent = observer(function MediaChatComponent({
         ],
         { duration: 1200 }
       );
+    };
+
+    for (let attempts = 0; attempts < 50; attempts++) {
+      const el = document.getElementById(
+        `msg-${messageId}`
+      ) as HTMLElement | null;
+      if (el) {
+        highlight(el);
+        return;
+      }
+
+      if (!messageStore.hasOlderMessages) break;
+
+      if (!messageStore.isLoadingOlder) {
+        const container = scrollHandler.messagesContainerRef.current;
+        if (container) {
+          scrollHandler.previousScrollHeight.current = container.scrollHeight;
+        }
+        messageStore.loadOlderMessages();
+      }
+
+      await new Promise((res) => setTimeout(res, 150));
     }
   };
 
@@ -247,9 +273,20 @@ const MediaChatComponent = observer(function MediaChatComponent({
                       cancel
                     </Box>
                   </Box>
-                  <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
                     {replyPreview?.type && replyPreview.type !== "Text"
-                      ? `📎 ${replyPreview?.mediaOriginalFileName || replyPreview?.type}`
+                      ? `📎 ${
+                          replyPreview?.mediaOriginalFileName ||
+                          replyPreview?.type
+                        }`
                       : replyPreview?.body}
                   </Typography>
                 </CardContent>

--- a/client/src/lib/hooks/useDirectMessages.ts
+++ b/client/src/lib/hooks/useDirectMessages.ts
@@ -48,9 +48,24 @@ export const useDirectMessages = (directChatId?: string) => {
         "LoadDirectMessages",
         (pagedResult: PagedList<DirectMessage, Date>) => {
           runInAction(() => {
-            this.messages = pagedResult.items;
-            this.hasOlderMessages = !!pagedResult.nextCursor;
-            this.oldestMessageCursor = pagedResult.nextCursor;
+            if (this.messages.length > 0) {
+              const existingIds = new Set(this.messages.map((m) => m.id));
+              const toAppend = pagedResult.items.filter(
+                (m) => !existingIds.has(m.id)
+              );
+              if (toAppend.length > 0) {
+                this.messages.push(...toAppend);
+              }
+              this.hasOlderMessages =
+                this.hasOlderMessages || !!pagedResult.nextCursor;
+              if (!this.oldestMessageCursor && pagedResult.nextCursor) {
+                this.oldestMessageCursor = pagedResult.nextCursor;
+              }
+            } else {
+              this.messages = pagedResult.items;
+              this.hasOlderMessages = !!pagedResult.nextCursor;
+              this.oldestMessageCursor = pagedResult.nextCursor;
+            }
           });
         }
       );

--- a/client/src/lib/hooks/useMessages.ts
+++ b/client/src/lib/hooks/useMessages.ts
@@ -47,9 +47,24 @@ export const useMessages = (chatRoomId?: string) => {
         "LoadMessages",
         (pagedResult: PagedList<ChatMessage, Date>) => {
           runInAction(() => {
-            this.messages = pagedResult.items;
-            this.hasOlderMessages = !!pagedResult.nextCursor;
-            this.oldestMessageCursor = pagedResult.nextCursor;
+            if (this.messages.length > 0) {
+              const existingIds = new Set(this.messages.map((m) => m.id));
+              const toAppend = pagedResult.items.filter(
+                (m) => !existingIds.has(m.id)
+              );
+              if (toAppend.length > 0) {
+                this.messages.push(...toAppend);
+              }
+              this.hasOlderMessages =
+                this.hasOlderMessages || !!pagedResult.nextCursor;
+              if (!this.oldestMessageCursor && pagedResult.nextCursor) {
+                this.oldestMessageCursor = pagedResult.nextCursor;
+              }
+            } else {
+              this.messages = pagedResult.items;
+              this.hasOlderMessages = !!pagedResult.nextCursor;
+              this.oldestMessageCursor = pagedResult.nextCursor;
+            }
           });
         }
       );


### PR DESCRIPTION
This pull request improves the chat message loading and reply experience in the media chat component. The main changes include making the "jump to message" feature more robust by attempting to load older messages if the target message isn't found, and ensuring that duplicate messages are not appended when loading older messages in both direct and group chats.

**Chat message navigation and loading improvements:**

* Enhanced the `handleJumpToMessage` function in `MediaChatComponent.tsx` to repeatedly attempt to find and highlight a message, loading older messages if needed, making jumping to a specific message much more reliable. [[1]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192L165-R171) [[2]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192R181-R202)
* Updated message loading logic in `useMessages.ts` and `useDirectMessages.ts` to avoid appending duplicate messages when loading older messages, improving data consistency and preventing UI issues. [[1]](diffhunk://#diff-c1c4de67f259ec1a01c978c662565830b35c65fb9ff56b9adcb844afab784f8aR50-R67) [[2]](diffhunk://#diff-ad01fd8ebe340f5f0f83b7f61be13d8b507feeedbc15cfa9bc9a65f153a6bf7aR51-R68)

**Reply preview and UI improvements:**

* Refactored the reply preview state type definition in `MediaChatComponent.tsx` for better readability and maintainability.
* Improved the reply preview UI in `MediaChatComponent.tsx` by formatting the attachment display logic for clarity and readability.Fixes #61

Fixes #60 