### PR TITLE
PR add option to send multiple media files at once

### DIFF
--- a/client/src/app/shared/components/mediaChatComponent/ChatInput.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatInput.tsx
@@ -11,7 +11,6 @@ interface ChatInputProps {
   defaultEmoji: string;
   isSubmitting: boolean;
   isUploading: boolean;
-  hasFileAttached: boolean;
   hasPermission: boolean;
   placeholder?: string;
 }
@@ -24,7 +23,6 @@ export default function ChatInput({
   defaultEmoji,
   isSubmitting,
   isUploading,
-  hasFileAttached,
   hasPermission = true,
   placeholder = "Enter your message (Enter to submit, Ctrl+V to paste images, SHIFT + Enter for new line)",
 }: ChatInputProps) {
@@ -90,7 +88,7 @@ export default function ChatInput({
         color="primary"
         sx={{ mb: 0.5 }}
         title="Attach file"
-        disabled={hasFileAttached}
+        disabled={!hasPermission || isSubmitting || isUploading}
       >
         <AttachFile />
       </IconButton>

--- a/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
@@ -197,7 +197,7 @@ export default function ChatMessageList({
                       }}
                     >
                       {message.replyToType && message.replyToType !== "Text"
-                        ? `Ы"� ${
+                        ? `📎 ${
                             message.replyToMediaOriginalFileName ||
                             message.replyToType
                           }`

--- a/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, CircularProgress, Chip, Typography, IconButton, Paper } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Chip,
+  Typography,
+  IconButton,
+  Paper,
+} from "@mui/material";
 import { ReplyOutlined } from "@mui/icons-material";
 import { Link } from "react-router";
 import { timeAgo } from "../../../../lib/util/util";
@@ -30,7 +38,6 @@ export default function ChatMessageList({
   onReplyClick,
   onJumpToMessage,
 }: ChatMessageListProps) {
-  // Build grouped render items: consecutive Images/Videos by same sender within short window
   type RenderItem =
     | { kind: "single"; message: BaseMessage }
     | { kind: "group"; type: "Image" | "Video"; messages: BaseMessage[] };
@@ -38,7 +45,7 @@ export default function ChatMessageList({
   const buildRenderItems = (): RenderItem[] => {
     const items: RenderItem[] = [];
     const msgs = messageStore.messages;
-    const timeWindowMs = 15 * 1000; // 15 seconds
+    const timeWindowMs = 15 * 1000;
 
     let i = 0;
     while (i < msgs.length) {
@@ -51,7 +58,7 @@ export default function ChatMessageList({
         let j = i + 1;
         while (j < msgs.length) {
           const n = msgs[j];
-          if ((n.type === groupType) && ((n.senderId || n.userId) === sender)) {
+          if (n.type === groupType && (n.senderId || n.userId) === sender) {
             const tj = new Date(n.createdAt).getTime();
             if (Math.abs(tj - t0) <= timeWindowMs) {
               group.push(n);
@@ -107,12 +114,16 @@ export default function ChatMessageList({
         </Box>
       )}
 
-      {/* Messages list (with grouping) */}
+      {/* Messages list */}
       {renderItems.map((item, idx) => {
         if (item.kind === "single") {
           const message = item.message;
           return (
-            <Box key={message.id} id={`msg-${message.id}`} sx={{ display: "flex", mb: 2 }}>
+            <Box
+              key={message.id}
+              id={`msg-${message.id}`}
+              sx={{ display: "flex", mb: 2 }}
+            >
               <MessageAvatarWithStatus
                 userId={message.senderId || message.userId || ""}
                 imageUrl={message.senderImageUrl || message.imageUrl}
@@ -162,15 +173,34 @@ export default function ChatMessageList({
                 {message.replyToMessageId && (
                   <Paper
                     variant="outlined"
-                    sx={{ p: 1, mb: 1, bgcolor: "action.hover", cursor: onJumpToMessage ? "pointer" : "default" }}
-                    onClick={() => onJumpToMessage && onJumpToMessage(message.replyToMessageId!)}
+                    sx={{
+                      p: 1,
+                      mb: 1,
+                      bgcolor: "action.hover",
+                      cursor: onJumpToMessage ? "pointer" : "default",
+                    }}
+                    onClick={() =>
+                      onJumpToMessage &&
+                      onJumpToMessage(message.replyToMessageId!)
+                    }
                   >
                     <Typography variant="caption" sx={{ fontWeight: 700 }}>
                       Replying to {message.replyToDisplayName || "message"}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
                       {message.replyToType && message.replyToType !== "Text"
-                        ? `Ы"� ${message.replyToMediaOriginalFileName || message.replyToType}`
+                        ? `Ы"� ${
+                            message.replyToMediaOriginalFileName ||
+                            message.replyToType
+                          }`
                         : message.replyToBody || ""}
                     </Typography>
                   </Paper>
@@ -187,9 +217,14 @@ export default function ChatMessageList({
         }
 
         const first = item.messages[0];
-        const displayName = first.senderDisplayName || first.displayName || "Unknown";
+        const displayName =
+          first.senderDisplayName || first.displayName || "Unknown";
         return (
-          <Box key={`group-${first.id}-${idx}`} id={`msg-${first.id}`} sx={{ display: "flex", mb: 2 }}>
+          <Box
+            key={`group-${first.id}-${idx}`}
+            id={`msg-${first.id}`}
+            sx={{ display: "flex", mb: 2 }}
+          >
             <MessageAvatarWithStatus
               userId={first.senderId || first.userId || ""}
               imageUrl={first.senderImageUrl || first.imageUrl}
@@ -200,7 +235,11 @@ export default function ChatMessageList({
               <Box display="flex" alignItems="center" gap={3}>
                 <Typography
                   component={showUserProfiles ? Link : "span"}
-                  to={showUserProfiles ? `/profiles/${first.senderId || first.userId}` : undefined}
+                  to={
+                    showUserProfiles
+                      ? `/profiles/${first.senderId || first.userId}`
+                      : undefined
+                  }
                   variant="subtitle1"
                   sx={{ fontWeight: "bold", textDecoration: "none" }}
                 >
@@ -209,7 +248,12 @@ export default function ChatMessageList({
                 <Typography variant="body2" color="textSecondary">
                   {timeAgo(first.createdAt)}
                 </Typography>
-                <Chip size="small" label={item.type} color="primary" variant="outlined" />
+                <Chip
+                  size="small"
+                  label={item.type}
+                  color="primary"
+                  variant="outlined"
+                />
                 {onReplyClick && (
                   <IconButton
                     size="small"
@@ -225,21 +269,43 @@ export default function ChatMessageList({
               {first.replyToMessageId && (
                 <Paper
                   variant="outlined"
-                  sx={{ p: 1, mb: 1, bgcolor: "action.hover", cursor: onJumpToMessage ? "pointer" : "default" }}
-                  onClick={() => onJumpToMessage && onJumpToMessage(first.replyToMessageId!)}
+                  sx={{
+                    p: 1,
+                    mb: 1,
+                    bgcolor: "action.hover",
+                    cursor: onJumpToMessage ? "pointer" : "default",
+                  }}
+                  onClick={() =>
+                    onJumpToMessage && onJumpToMessage(first.replyToMessageId!)
+                  }
                 >
                   <Typography variant="caption" sx={{ fontWeight: 700 }}>
                     Replying to {first.replyToDisplayName || "message"}
                   </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
                     {first.replyToType && first.replyToType !== "Text"
-                      ? `Ы"� ${first.replyToMediaOriginalFileName || first.replyToType}`
+                      ? `Ы"� ${
+                          first.replyToMediaOriginalFileName ||
+                          first.replyToType
+                        }`
                       : first.replyToBody || ""}
                   </Typography>
                 </Paper>
               )}
 
-              <GroupedMediaMessage type={item.type} messages={item.messages} onImageClick={onImageClick} />
+              <GroupedMediaMessage
+                type={item.type}
+                messages={item.messages}
+                onImageClick={onImageClick}
+              />
             </Box>
           </Box>
         );
@@ -249,4 +315,3 @@ export default function ChatMessageList({
     </>
   );
 }
-

--- a/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
@@ -292,7 +292,7 @@ export default function ChatMessageList({
                     }}
                   >
                     {first.replyToType && first.replyToType !== "Text"
-                      ? `Ы"� ${
+                      ? `📎 ${
                           first.replyToMediaOriginalFileName ||
                           first.replyToType
                         }`

--- a/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx
@@ -4,7 +4,8 @@ import { Link } from "react-router";
 import { timeAgo } from "../../../../lib/util/util";
 import MessageAvatarWithStatus from "../MessageAvatarWithStatus";
 import MessageContentRenderer from "./MessageContentRenderer";
-import type { BaseMessageStore } from "../../../../lib/types";
+import GroupedMediaMessage from "./GroupedMediaMessage";
+import type { BaseMessage, BaseMessageStore } from "../../../../lib/types";
 
 interface ChatMessageListProps {
   messageStore: BaseMessageStore;
@@ -29,6 +30,54 @@ export default function ChatMessageList({
   onReplyClick,
   onJumpToMessage,
 }: ChatMessageListProps) {
+  // Build grouped render items: consecutive Images/Videos by same sender within short window
+  type RenderItem =
+    | { kind: "single"; message: BaseMessage }
+    | { kind: "group"; type: "Image" | "Video"; messages: BaseMessage[] };
+
+  const buildRenderItems = (): RenderItem[] => {
+    const items: RenderItem[] = [];
+    const msgs = messageStore.messages;
+    const timeWindowMs = 15 * 1000; // 15 seconds
+
+    let i = 0;
+    while (i < msgs.length) {
+      const m = msgs[i];
+      if (m.type === "Image" || m.type === "Video") {
+        const sender = m.senderId || m.userId;
+        const t0 = new Date(m.createdAt).getTime();
+        const groupType = m.type;
+        const group: BaseMessage[] = [m];
+        let j = i + 1;
+        while (j < msgs.length) {
+          const n = msgs[j];
+          if ((n.type === groupType) && ((n.senderId || n.userId) === sender)) {
+            const tj = new Date(n.createdAt).getTime();
+            if (Math.abs(tj - t0) <= timeWindowMs) {
+              group.push(n);
+              j++;
+              continue;
+            }
+          }
+          break;
+        }
+        if (group.length > 1) {
+          items.push({ kind: "group", type: groupType, messages: group });
+          i = j;
+          continue;
+        }
+        items.push({ kind: "single", message: m });
+        i++;
+      } else {
+        items.push({ kind: "single", message: m });
+        i++;
+      }
+    }
+    return items;
+  };
+
+  const renderItems = buildRenderItems();
+
   return (
     <>
       {/* Load older messages indicator */}
@@ -58,82 +107,146 @@ export default function ChatMessageList({
         </Box>
       )}
 
-      {/* Messages list */}
-      {messageStore.messages.map((message) => (
-        <Box key={message.id} id={`msg-${message.id}`} sx={{ display: "flex", mb: 2 }}>
-          <MessageAvatarWithStatus
-            userId={message.senderId || message.userId || ""}
-            imageUrl={message.senderImageUrl || message.imageUrl}
-            displayName={
-              message.senderDisplayName || message.displayName || "Unknown"
-            }
-            showUserProfiles={showUserProfiles}
-          />
-          <Box display="flex" flexDirection="column" sx={{ flex: 1 }}>
-            <Box display="flex" alignItems="center" gap={3}>
-              <Typography
-                component={showUserProfiles ? Link : "span"}
-                to={
-                  showUserProfiles
-                    ? `/profiles/${message.senderId || message.userId}`
-                    : undefined
+      {/* Messages list (with grouping) */}
+      {renderItems.map((item, idx) => {
+        if (item.kind === "single") {
+          const message = item.message;
+          return (
+            <Box key={message.id} id={`msg-${message.id}`} sx={{ display: "flex", mb: 2 }}>
+              <MessageAvatarWithStatus
+                userId={message.senderId || message.userId || ""}
+                imageUrl={message.senderImageUrl || message.imageUrl}
+                displayName={
+                  message.senderDisplayName || message.displayName || "Unknown"
                 }
-                variant="subtitle1"
-                sx={{ fontWeight: "bold", textDecoration: "none" }}
-              >
-                {message.senderDisplayName || message.displayName}
-              </Typography>
-              <Typography variant="body2" color="textSecondary">
-                {timeAgo(message.createdAt)}
-              </Typography>
-              {message.type !== "Text" && (
-                <Chip
-                  size="small"
-                  label={message.type}
-                  color="primary"
-                  variant="outlined"
+                showUserProfiles={showUserProfiles}
+              />
+              <Box display="flex" flexDirection="column" sx={{ flex: 1 }}>
+                <Box display="flex" alignItems="center" gap={3}>
+                  <Typography
+                    component={showUserProfiles ? Link : "span"}
+                    to={
+                      showUserProfiles
+                        ? `/profiles/${message.senderId || message.userId}`
+                        : undefined
+                    }
+                    variant="subtitle1"
+                    sx={{ fontWeight: "bold", textDecoration: "none" }}
+                  >
+                    {message.senderDisplayName || message.displayName}
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    {timeAgo(message.createdAt)}
+                  </Typography>
+                  {message.type !== "Text" && (
+                    <Chip
+                      size="small"
+                      label={message.type}
+                      color="primary"
+                      variant="outlined"
+                    />
+                  )}
+                  {onReplyClick && (
+                    <IconButton
+                      size="small"
+                      sx={{ ml: "auto" }}
+                      title="Reply"
+                      onClick={() => onReplyClick(message.id)}
+                    >
+                      <ReplyOutlined fontSize="small" />
+                    </IconButton>
+                  )}
+                </Box>
+
+                {/* Replied-to preview */}
+                {message.replyToMessageId && (
+                  <Paper
+                    variant="outlined"
+                    sx={{ p: 1, mb: 1, bgcolor: "action.hover", cursor: onJumpToMessage ? "pointer" : "default" }}
+                    onClick={() => onJumpToMessage && onJumpToMessage(message.replyToMessageId!)}
+                  >
+                    <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                      Replying to {message.replyToDisplayName || "message"}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {message.replyToType && message.replyToType !== "Text"
+                        ? `Ы"� ${message.replyToMediaOriginalFileName || message.replyToType}`
+                        : message.replyToBody || ""}
+                    </Typography>
+                  </Paper>
+                )}
+
+                <MessageContentRenderer
+                  message={message}
+                  onImageClick={onImageClick}
+                  onFileDownload={onFileDownload}
                 />
-              )}
-              {onReplyClick && (
-                <IconButton
-                  size="small"
-                  sx={{ ml: "auto" }}
-                  title="Reply"
-                  onClick={() => onReplyClick(message.id)}
-                >
-                  <ReplyOutlined fontSize="small" />
-                </IconButton>
-              )}
+              </Box>
             </Box>
+          );
+        }
 
-            {/* Replied-to preview */}
-            {message.replyToMessageId && (
-              <Paper
-                variant="outlined"
-                sx={{ p: 1, mb: 1, bgcolor: "action.hover", cursor: onJumpToMessage ? "pointer" : "default" }}
-                onClick={() => onJumpToMessage && onJumpToMessage(message.replyToMessageId!)}
-              >
-                <Typography variant="caption" sx={{ fontWeight: 700 }}>
-                  Replying to {message.replyToDisplayName || "message"}
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                  {message.replyToType && message.replyToType !== "Text"
-                    ? `📎 ${message.replyToMediaOriginalFileName || message.replyToType}`
-                    : message.replyToBody || ""}
-                </Typography>
-              </Paper>
-            )}
-
-            <MessageContentRenderer
-              message={message}
-              onImageClick={onImageClick}
-              onFileDownload={onFileDownload}
+        const first = item.messages[0];
+        const displayName = first.senderDisplayName || first.displayName || "Unknown";
+        return (
+          <Box key={`group-${first.id}-${idx}`} id={`msg-${first.id}`} sx={{ display: "flex", mb: 2 }}>
+            <MessageAvatarWithStatus
+              userId={first.senderId || first.userId || ""}
+              imageUrl={first.senderImageUrl || first.imageUrl}
+              displayName={displayName}
+              showUserProfiles={showUserProfiles}
             />
+            <Box display="flex" flexDirection="column" sx={{ flex: 1 }}>
+              <Box display="flex" alignItems="center" gap={3}>
+                <Typography
+                  component={showUserProfiles ? Link : "span"}
+                  to={showUserProfiles ? `/profiles/${first.senderId || first.userId}` : undefined}
+                  variant="subtitle1"
+                  sx={{ fontWeight: "bold", textDecoration: "none" }}
+                >
+                  {displayName}
+                </Typography>
+                <Typography variant="body2" color="textSecondary">
+                  {timeAgo(first.createdAt)}
+                </Typography>
+                <Chip size="small" label={item.type} color="primary" variant="outlined" />
+                {onReplyClick && (
+                  <IconButton
+                    size="small"
+                    sx={{ ml: "auto" }}
+                    title="Reply"
+                    onClick={() => onReplyClick(first.id)}
+                  >
+                    <ReplyOutlined fontSize="small" />
+                  </IconButton>
+                )}
+              </Box>
+
+              {first.replyToMessageId && (
+                <Paper
+                  variant="outlined"
+                  sx={{ p: 1, mb: 1, bgcolor: "action.hover", cursor: onJumpToMessage ? "pointer" : "default" }}
+                  onClick={() => onJumpToMessage && onJumpToMessage(first.replyToMessageId!)}
+                >
+                  <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                    Replying to {first.replyToDisplayName || "message"}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {first.replyToType && first.replyToType !== "Text"
+                      ? `Ы"� ${first.replyToMediaOriginalFileName || first.replyToType}`
+                      : first.replyToBody || ""}
+                  </Typography>
+                </Paper>
+              )}
+
+              <GroupedMediaMessage type={item.type} messages={item.messages} onImageClick={onImageClick} />
+            </Box>
           </Box>
-        </Box>
-      ))}
+        );
+      })}
 
       <div ref={messagesEndRef} />
     </>
   );
 }
+

--- a/client/src/app/shared/components/mediaChatComponent/GroupedMediaMessage.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/GroupedMediaMessage.tsx
@@ -1,0 +1,64 @@
+import { Box, Typography } from "@mui/material";
+import type { BaseMessage } from "../../../../lib/types";
+import Linkify from "linkify-react";
+import { convertTextToEmoji } from "../../../../lib/util/emojiUtils";
+
+type Props = {
+  type: "Image" | "Video";
+  messages: BaseMessage[];
+  onImageClick: (src: string) => void;
+};
+
+export default function GroupedMediaMessage({ type, messages, onImageClick }: Props) {
+  const first = messages[0];
+  const showBody = first.body && first.body !== first.mediaOriginalFileName;
+
+  const linkifyOptions = {
+    target: "_blank",
+    rel: "noopener noreferrer",
+    className: undefined,
+    attributes: () => ({ rel: "noopener noreferrer", target: "_blank" }),
+  };
+
+  return (
+    <Box>
+      {showBody && (
+        <Typography sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word", mb: 1 }}>
+          <Linkify options={linkifyOptions}>{convertTextToEmoji(first.body)}</Linkify>
+        </Typography>
+      )}
+
+      <Box
+        sx={{
+          display: "grid",
+          gap: 1,
+          gridTemplateColumns: {
+            xs: "repeat(2, 1fr)",
+            sm: "repeat(3, 1fr)",
+            md: "repeat(4, 1fr)",
+          },
+        }}
+      >
+        {messages.map((m) => (
+          <Box key={m.id} sx={{ borderRadius: 2, overflow: "hidden" }}>
+            {type === "Image" ? (
+              <img
+                src={m.mediaUrl || ""}
+                alt={m.mediaOriginalFileName || "image"}
+                style={{ width: "100%", height: 180, objectFit: "cover", cursor: "pointer" }}
+                onClick={() => m.mediaUrl && onImageClick(m.mediaUrl)}
+              />
+            ) : (
+              <video
+                src={m.mediaUrl || ""}
+                style={{ width: "100%", height: 200, objectFit: "cover" }}
+                controls
+              />
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+

--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -12,6 +12,7 @@ import ChatHeader from "./ChatHeader";
 import DragOverlay from "./DragOverlay";
 import ChatMessageList from "./ChatMessageList";
 import { FilePreview } from "./FilePreview";
+import MultiFilePreview from "./MultiFilePreview";
 import ChatInput from "./ChatInput";
 import ImageViewerDialog from "./ImageViewerDialog";
 import { useEmojiPreferences } from "../../../../lib/hooks/useEmojiPreferences";
@@ -103,8 +104,8 @@ const MediaChatComponent = observer(function MediaChatComponent({
         return;
       }
 
-      if (fileUpload.selectedFile) {
-        await fileUpload.uploadSelectedFile(data.body);
+      if (fileUpload.selectedItems && fileUpload.selectedItems.length > 0) {
+        await fileUpload.uploadSelectedFiles(data.body);
         return;
       }
 
@@ -140,14 +141,15 @@ const MediaChatComponent = observer(function MediaChatComponent({
       event.preventDefault();
       if (fileUpload.pendingPaste.file) {
         fileUpload.clearPendingPaste();
-      } else if (fileUpload.selectedFile) {
-        fileUpload.clearSelectedFile();
+      } else if (fileUpload.selectedItems.length > 0) {
+        fileUpload.clearSelectedFiles();
       }
     }
   };
 
   const hasFileAttached = !!(
-    fileUpload.pendingPaste.file || fileUpload.selectedFile
+    fileUpload.pendingPaste.file ||
+    (fileUpload.selectedItems && fileUpload.selectedItems.length > 0)
   );
 
   const handleReplyClick = (messageId: string) => {
@@ -266,12 +268,13 @@ const MediaChatComponent = observer(function MediaChatComponent({
                 />
               )}
 
-            {fileUpload.selectedFile && fileUpload.mediaPreview && (
-              <FilePreview
-                file={fileUpload.selectedFile}
-                preview={fileUpload.mediaPreview}
-                onRemove={fileUpload.clearSelectedFile}
-                type="selected"
+            {fileUpload.selectedItems && fileUpload.selectedItems.length > 0 && (
+              <MultiFilePreview
+                items={fileUpload.selectedItems}
+                totalSize={fileUpload.totalSelectedSize}
+                maxTotalSize={fileUpload.MAX_TOTAL_SIZE}
+                onRemove={(id) => fileUpload.removeSelectedItem(id)}
+                onClearAll={fileUpload.clearSelectedFiles}
               />
             )}
 
@@ -283,7 +286,6 @@ const MediaChatComponent = observer(function MediaChatComponent({
                 defaultEmoji={defaultEmoji}
                 isSubmitting={false}
                 isUploading={fileUpload.isUploading}
-                hasFileAttached={hasFileAttached}
                 hasPermission={
                   chatRoomId === undefined
                     ? true
@@ -308,6 +310,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
         ref={fileUpload.fileInputRef}
         type="file"
         hidden
+        multiple
         accept="image/*,video/*,audio/*,.pdf,.doc,.docx,.txt,.md,.js,.ts,.py,.java,.cs,.cpp,.c,.h,.php,.rb,.go,.rs,.swift,.kt,.scala,.yml,.yaml,.json,.xml,.html,.css,.sql,.sh,.bat,.ps1,.zip,.rar,.7z,.gz,.tar"
         onChange={fileUpload.handleFileChange}
       />

--- a/client/src/app/shared/components/mediaChatComponent/MultiFilePreview.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MultiFilePreview.tsx
@@ -1,4 +1,10 @@
-import { Box, Typography, IconButton, Chip, LinearProgress } from "@mui/material";
+import {
+  Box,
+  Typography,
+  IconButton,
+  Chip,
+  LinearProgress,
+} from "@mui/material";
 import { Close } from "@mui/icons-material";
 
 type PreviewItem = {
@@ -38,10 +44,19 @@ export default function MultiFilePreview({
   const percent = Math.min(100, Math.round((totalSize / maxTotalSize) * 100));
 
   return (
-    <Box sx={{ mb: 2, p: 2, border: "1px solid", borderColor: "divider", borderRadius: 2 }}>
+    <Box
+      sx={{
+        mb: 2,
+        p: 2,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 2,
+      }}
+    >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
         <Typography variant="body2" fontWeight={700}>
-          Selected files: {items.length} ({formatFileSize(totalSize)} / {formatFileSize(maxTotalSize)})
+          Selected files: {items.length} ({formatFileSize(totalSize)} /{" "}
+          {formatFileSize(maxTotalSize)})
         </Typography>
         <Box sx={{ flex: 1 }} />
         <Chip label="Clear all" size="small" onClick={onClearAll} />
@@ -50,22 +65,42 @@ export default function MultiFilePreview({
 
       {images.length > 0 && (
         <Box sx={{ mb: 2 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", mb: 1 }}
+          >
             Images
           </Typography>
-          <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(80px, 1fr))", gap: 1 }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(80px, 1fr))",
+              gap: 1,
+            }}
+          >
             {images.map((i) => (
               <Box key={i.id} sx={{ position: "relative" }}>
                 <img
                   src={i.preview || ""}
                   alt={i.file.name}
-                  style={{ width: "100%", height: 80, objectFit: "cover", borderRadius: 8 }}
+                  style={{
+                    width: "100%",
+                    height: 80,
+                    objectFit: "cover",
+                    borderRadius: 8,
+                  }}
                 />
                 <IconButton
                   size="small"
                   color="error"
                   onClick={() => onRemove(i.id)}
-                  sx={{ position: "absolute", top: 2, right: 2, bgcolor: "background.paper" }}
+                  sx={{
+                    position: "absolute",
+                    top: 2,
+                    right: 2,
+                    bgcolor: "background.paper",
+                  }}
                 >
                   <Close fontSize="small" />
                 </IconButton>
@@ -77,18 +112,38 @@ export default function MultiFilePreview({
 
       {videos.length > 0 && (
         <Box sx={{ mb: 2 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", mb: 1 }}
+          >
             Videos
           </Typography>
-          <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))", gap: 1 }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
+              gap: 1,
+            }}
+          >
             {videos.map((i) => (
               <Box key={i.id} sx={{ position: "relative" }}>
-                <video src={i.preview || ""} muted controls style={{ width: "100%", height: 100, borderRadius: 8 }} />
+                <video
+                  src={i.preview || ""}
+                  muted
+                  controls
+                  style={{ width: "100%", height: 100, borderRadius: 8 }}
+                />
                 <IconButton
                   size="small"
                   color="error"
                   onClick={() => onRemove(i.id)}
-                  sx={{ position: "absolute", top: 2, right: 2, bgcolor: "background.paper" }}
+                  sx={{
+                    position: "absolute",
+                    top: 2,
+                    right: 2,
+                    bgcolor: "background.paper",
+                  }}
                 >
                   <Close fontSize="small" />
                 </IconButton>
@@ -100,7 +155,11 @@ export default function MultiFilePreview({
 
       {others.length > 0 && (
         <Box>
-          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: "block", mb: 1 }}
+          >
             Other files
           </Typography>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
@@ -120,7 +179,12 @@ export default function MultiFilePreview({
                 <Typography variant="body2" sx={{ flex: 1 }}>
                   {i.file.name} ({formatFileSize(i.file.size)})
                 </Typography>
-                <IconButton size="small" color="error" onClick={() => onRemove(i.id)} title="Remove">
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => onRemove(i.id)}
+                  title="Remove"
+                >
                   <Close fontSize="small" />
                 </IconButton>
               </Box>
@@ -129,10 +193,13 @@ export default function MultiFilePreview({
         </Box>
       )}
 
-      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 2 }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: "block", mt: 2 }}
+      >
         Add a message below and press Enter to send all.
       </Typography>
     </Box>
   );
 }
-

--- a/client/src/app/shared/components/mediaChatComponent/MultiFilePreview.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MultiFilePreview.tsx
@@ -1,0 +1,138 @@
+import { Box, Typography, IconButton, Chip, LinearProgress } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
+type PreviewItem = {
+  id: string;
+  file: File;
+  kind: "image" | "video" | "audio" | "other";
+  preview?: string | null;
+};
+
+type Props = {
+  items: PreviewItem[];
+  totalSize: number;
+  maxTotalSize: number;
+  onRemove: (id: string) => void;
+  onClearAll: () => void;
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+};
+
+export default function MultiFilePreview({
+  items,
+  totalSize,
+  maxTotalSize,
+  onRemove,
+  onClearAll,
+}: Props) {
+  const images = items.filter((i) => i.kind === "image");
+  const videos = items.filter((i) => i.kind === "video");
+  const others = items.filter((i) => i.kind !== "image" && i.kind !== "video");
+
+  const percent = Math.min(100, Math.round((totalSize / maxTotalSize) * 100));
+
+  return (
+    <Box sx={{ mb: 2, p: 2, border: "1px solid", borderColor: "divider", borderRadius: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+        <Typography variant="body2" fontWeight={700}>
+          Selected files: {items.length} ({formatFileSize(totalSize)} / {formatFileSize(maxTotalSize)})
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <Chip label="Clear all" size="small" onClick={onClearAll} />
+      </Box>
+      <LinearProgress variant="determinate" value={percent} sx={{ mb: 2 }} />
+
+      {images.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+            Images
+          </Typography>
+          <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(80px, 1fr))", gap: 1 }}>
+            {images.map((i) => (
+              <Box key={i.id} sx={{ position: "relative" }}>
+                <img
+                  src={i.preview || ""}
+                  alt={i.file.name}
+                  style={{ width: "100%", height: 80, objectFit: "cover", borderRadius: 8 }}
+                />
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => onRemove(i.id)}
+                  sx={{ position: "absolute", top: 2, right: 2, bgcolor: "background.paper" }}
+                >
+                  <Close fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {videos.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+            Videos
+          </Typography>
+          <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))", gap: 1 }}>
+            {videos.map((i) => (
+              <Box key={i.id} sx={{ position: "relative" }}>
+                <video src={i.preview || ""} muted controls style={{ width: "100%", height: 100, borderRadius: 8 }} />
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => onRemove(i.id)}
+                  sx={{ position: "absolute", top: 2, right: 2, bgcolor: "background.paper" }}
+                >
+                  <Close fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {others.length > 0 && (
+        <Box>
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+            Other files
+          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            {others.map((i) => (
+              <Box
+                key={i.id}
+                sx={{
+                  p: 1,
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                }}
+              >
+                <Typography variant="body2" sx={{ flex: 1 }}>
+                  {i.file.name} ({formatFileSize(i.file.size)})
+                </Typography>
+                <IconButton size="small" color="error" onClick={() => onRemove(i.id)} title="Remove">
+                  <Close fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 2 }}>
+        Add a message below and press Enter to send all.
+      </Typography>
+    </Box>
+  );
+}
+

--- a/client/src/lib/hooks/useFileUpload.ts
+++ b/client/src/lib/hooks/useFileUpload.ts
@@ -123,48 +123,65 @@ export function useFileUpload({
     return "other";
   };
 
-  const makeId = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
+  const makeId = (file: File) =>
+    `${file.name}:${file.size}:${file.lastModified}`;
 
-  const addFiles = useCallback((files: File[]) => {
-    if (!files || files.length === 0) return;
-    let addedCount = 0;
-    let skippedCount = 0;
+  const addFiles = useCallback(
+    (files: File[]) => {
+      if (!files || files.length === 0) return;
+      let addedCount = 0;
+      let skippedCount = 0;
 
-    setState((prev) => {
-      const currentSize = prev.selectedItems.reduce((s, it) => s + it.file.size, 0);
-      const newItems: SelectedItem[] = [];
-
-      for (const file of files) {
-        const willBe = currentSize + newItems.reduce((s, it) => s + it.file.size, 0) + file.size;
-        if (willBe > MAX_TOTAL_SIZE) {
-          skippedCount++;
-          continue;
-        }
-        const id = makeId(file);
-        if (prev.selectedItems.some((it) => it.id === id) || newItems.some((it) => it.id === id)) {
-          // avoid duplicates in this batch
-          continue;
-        }
-        const kind = kindOf(file);
-        const preview = kind === "image" || kind === "video" ? URL.createObjectURL(file) : null;
-        newItems.push({ id, file, kind, preview });
-        addedCount++;
-      }
-
-      // Toasting inside setState callback ensures counts are up to date post-calc
-      if (skippedCount > 0) {
-        toast.warn(
-          `File size limit reached (250MB). Added ${addedCount}, skipped ${skippedCount}.`
+      setState((prev) => {
+        const currentSize = prev.selectedItems.reduce(
+          (s, it) => s + it.file.size,
+          0
         );
-      }
+        const newItems: SelectedItem[] = [];
 
-      return { ...prev, selectedItems: [...prev.selectedItems, ...newItems] };
-    });
-  }, []);
+        for (const file of files) {
+          const willBe =
+            currentSize +
+            newItems.reduce((s, it) => s + it.file.size, 0) +
+            file.size;
+          if (willBe > MAX_TOTAL_SIZE) {
+            skippedCount++;
+            continue;
+          }
+          const id = makeId(file);
+          if (
+            prev.selectedItems.some((it) => it.id === id) ||
+            newItems.some((it) => it.id === id)
+          ) {
+            continue;
+          }
+          const kind = kindOf(file);
+          const preview =
+            kind === "image" || kind === "video"
+              ? URL.createObjectURL(file)
+              : null;
+          newItems.push({ id, file, kind, preview });
+          addedCount++;
+        }
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    addFiles(acceptedFiles);
-  }, [addFiles]);
+        if (skippedCount > 0) {
+          toast.warn(
+            `File size limit reached (250MB). Added ${addedCount}, skipped ${skippedCount}.`
+          );
+        }
+
+        return { ...prev, selectedItems: [...prev.selectedItems, ...newItems] };
+      });
+    },
+    [MAX_TOTAL_SIZE]
+  );
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      addFiles(acceptedFiles);
+    },
+    [addFiles]
+  );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -229,7 +246,7 @@ export function useFileUpload({
     },
     multiple: true,
     maxFiles: 100,
-    maxSize: 250 * 1024 * 1024, // per file cap; combined cap handled manually
+    maxSize: 250 * 1024 * 1024,
     noClick: true,
   });
 
@@ -242,7 +259,6 @@ export function useFileUpload({
     if (files.length) {
       addFiles(files);
     }
-    // allow the same file to be selected again in the future
     if (event.target) event.target.value = "";
   };
 
@@ -250,13 +266,18 @@ export function useFileUpload({
     setState((prev) => {
       const target = prev.selectedItems.find((it) => it.id === id);
       if (target?.preview) URL.revokeObjectURL(target.preview);
-      return { ...prev, selectedItems: prev.selectedItems.filter((it) => it.id !== id) };
+      return {
+        ...prev,
+        selectedItems: prev.selectedItems.filter((it) => it.id !== id),
+      };
     });
   };
 
   const clearSelectedFiles = () => {
     setState((prev) => {
-      prev.selectedItems.forEach((it) => it.preview && URL.revokeObjectURL(it.preview));
+      prev.selectedItems.forEach(
+        (it) => it.preview && URL.revokeObjectURL(it.preview)
+      );
       return { ...prev, selectedItems: [] };
     });
   };
@@ -278,16 +299,12 @@ export function useFileUpload({
       setIsBulkUploading(true);
       const trimmedBody = (messageBody || "").trim();
 
-      // Partition into groups: images, videos, others
       const images = state.selectedItems.filter((i) => i.kind === "image");
       const videos = state.selectedItems.filter((i) => i.kind === "video");
       const audios = state.selectedItems.filter((i) => i.kind === "audio");
       const others = state.selectedItems.filter((i) => i.kind === "other");
 
-      const sendOne = async (
-        file: File,
-        includeBody: boolean
-      ) => {
+      const sendOne = async (file: File, includeBody: boolean) => {
         const category = getMediaCategory(file);
         const messageType = getMessageType(file);
         const uploadResult = await uploadMedia.mutateAsync({
@@ -307,18 +324,15 @@ export function useFileUpload({
         });
       };
 
-      // Images: include body only on first image
       for (let idx = 0; idx < images.length; idx++) {
         await sendOne(images[idx].file, idx === 0);
       }
 
-      // Videos: include body only on first video (if no images were sent)
       for (let idx = 0; idx < videos.length; idx++) {
         const includeBody = images.length === 0 && idx === 0;
         await sendOne(videos[idx].file, includeBody);
       }
 
-      // Audios and others: send individually, include body only if none included yet
       const includeBodyForFirstDoc = images.length === 0 && videos.length === 0;
       let bodyUsed = includeBodyForFirstDoc;
       for (let i = 0; i < audios.length; i++) {

--- a/client/src/lib/hooks/useFileUpload.ts
+++ b/client/src/lib/hooks/useFileUpload.ts
@@ -1,12 +1,18 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useDropzone } from "react-dropzone";
 import { toast } from "react-toastify";
 import { useMedia, MediaCategory } from "./useMedia";
 import type { MediaUploadResult, MessageType } from "../types";
 
+type SelectedItem = {
+  id: string;
+  file: File;
+  kind: "image" | "video" | "audio" | "other";
+  preview?: string | null;
+};
+
 interface FileUploadState {
-  selectedFile: File | null;
-  mediaPreview: string | null;
+  selectedItems: SelectedItem[];
   pendingPaste: {
     file: File | null;
     preview: string | null;
@@ -29,10 +35,11 @@ export function useFileUpload({
   onReset,
 }: UseFileUploadProps) {
   const [state, setState] = useState<FileUploadState>({
-    selectedFile: null,
-    mediaPreview: null,
+    selectedItems: [],
     pendingPaste: { file: null, preview: null },
   });
+
+  const [isBulkUploading, setIsBulkUploading] = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { uploadMedia } = useMedia();
@@ -102,16 +109,62 @@ export function useFileUpload({
     return "Document";
   };
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    const file = acceptedFiles[0];
-    if (file) {
-      setState((prev) => ({
-        ...prev,
-        selectedFile: file,
-        mediaPreview: URL.createObjectURL(file),
-      }));
-    }
+  const MAX_TOTAL_SIZE = 250 * 1024 * 1024; // 250MB
+
+  const totalSelectedSize = useMemo(
+    () => state.selectedItems.reduce((sum, i) => sum + i.file.size, 0),
+    [state.selectedItems]
+  );
+
+  const kindOf = (file: File): SelectedItem["kind"] => {
+    if (file.type.startsWith("image/")) return "image";
+    if (file.type.startsWith("video/")) return "video";
+    if (file.type.startsWith("audio/")) return "audio";
+    return "other";
+  };
+
+  const makeId = (file: File) => `${file.name}:${file.size}:${file.lastModified}`;
+
+  const addFiles = useCallback((files: File[]) => {
+    if (!files || files.length === 0) return;
+    let addedCount = 0;
+    let skippedCount = 0;
+
+    setState((prev) => {
+      const currentSize = prev.selectedItems.reduce((s, it) => s + it.file.size, 0);
+      const newItems: SelectedItem[] = [];
+
+      for (const file of files) {
+        const willBe = currentSize + newItems.reduce((s, it) => s + it.file.size, 0) + file.size;
+        if (willBe > MAX_TOTAL_SIZE) {
+          skippedCount++;
+          continue;
+        }
+        const id = makeId(file);
+        if (prev.selectedItems.some((it) => it.id === id) || newItems.some((it) => it.id === id)) {
+          // avoid duplicates in this batch
+          continue;
+        }
+        const kind = kindOf(file);
+        const preview = kind === "image" || kind === "video" ? URL.createObjectURL(file) : null;
+        newItems.push({ id, file, kind, preview });
+        addedCount++;
+      }
+
+      // Toasting inside setState callback ensures counts are up to date post-calc
+      if (skippedCount > 0) {
+        toast.warn(
+          `File size limit reached (250MB). Added ${addedCount}, skipped ${skippedCount}.`
+        );
+      }
+
+      return { ...prev, selectedItems: [...prev.selectedItems, ...newItems] };
+    });
   }, []);
+
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    addFiles(acceptedFiles);
+  }, [addFiles]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -174,8 +227,9 @@ export function useFileUpload({
         ".ps1",
       ],
     },
-    maxFiles: 1,
-    maxSize: 200 * 1024 * 1024,
+    multiple: true,
+    maxFiles: 100,
+    maxSize: 250 * 1024 * 1024, // per file cap; combined cap handled manually
     noClick: true,
   });
 
@@ -184,25 +238,27 @@ export function useFileUpload({
   };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      setState((prev) => ({
-        ...prev,
-        selectedFile: file,
-        mediaPreview: URL.createObjectURL(file),
-      }));
+    const files = event.target.files ? Array.from(event.target.files) : [];
+    if (files.length) {
+      addFiles(files);
     }
+    // allow the same file to be selected again in the future
+    if (event.target) event.target.value = "";
   };
 
-  const clearSelectedFile = () => {
-    if (state.mediaPreview) {
-      URL.revokeObjectURL(state.mediaPreview);
-    }
-    setState((prev) => ({
-      ...prev,
-      selectedFile: null,
-      mediaPreview: null,
-    }));
+  const removeSelectedItem = (id: string) => {
+    setState((prev) => {
+      const target = prev.selectedItems.find((it) => it.id === id);
+      if (target?.preview) URL.revokeObjectURL(target.preview);
+      return { ...prev, selectedItems: prev.selectedItems.filter((it) => it.id !== id) };
+    });
+  };
+
+  const clearSelectedFiles = () => {
+    setState((prev) => {
+      prev.selectedItems.forEach((it) => it.preview && URL.revokeObjectURL(it.preview));
+      return { ...prev, selectedItems: [] };
+    });
   };
 
   const clearPendingPaste = () => {
@@ -215,35 +271,72 @@ export function useFileUpload({
     }));
   };
 
-  const uploadSelectedFile = async (messageBody: string) => {
-    const { selectedFile } = state;
-    if (!selectedFile) return;
+  const uploadSelectedFiles = async (messageBody: string) => {
+    if (state.selectedItems.length === 0) return;
 
     try {
-      const category = getMediaCategory(selectedFile);
-      const messageType = getMessageType(selectedFile);
+      setIsBulkUploading(true);
+      const trimmedBody = (messageBody || "").trim();
 
-      const uploadResult = await uploadMedia.mutateAsync({
-        file: selectedFile,
-        category,
-        ...(chatRoomId && { chatRoomId }),
-      });
+      // Partition into groups: images, videos, others
+      const images = state.selectedItems.filter((i) => i.kind === "image");
+      const videos = state.selectedItems.filter((i) => i.kind === "video");
+      const audios = state.selectedItems.filter((i) => i.kind === "audio");
+      const others = state.selectedItems.filter((i) => i.kind === "other");
 
-      const body = messageBody.trim() || selectedFile.name;
+      const sendOne = async (
+        file: File,
+        includeBody: boolean
+      ) => {
+        const category = getMediaCategory(file);
+        const messageType = getMessageType(file);
+        const uploadResult = await uploadMedia.mutateAsync({
+          file,
+          category,
+          ...(chatRoomId && { chatRoomId }),
+        });
 
-      await onUpload(body, messageType, {
-        url: uploadResult.url,
-        publicId: uploadResult.publicId,
-        mediaType: uploadResult.mediaType,
-        fileSize: uploadResult.fileSize,
-        originalFileName: uploadResult.originalFileName,
-      });
+        const body = includeBody && trimmedBody ? trimmedBody : file.name;
 
-      clearSelectedFile();
+        await onUpload(body, messageType, {
+          url: uploadResult.url,
+          publicId: uploadResult.publicId,
+          mediaType: uploadResult.mediaType,
+          fileSize: uploadResult.fileSize,
+          originalFileName: uploadResult.originalFileName,
+        });
+      };
+
+      // Images: include body only on first image
+      for (let idx = 0; idx < images.length; idx++) {
+        await sendOne(images[idx].file, idx === 0);
+      }
+
+      // Videos: include body only on first video (if no images were sent)
+      for (let idx = 0; idx < videos.length; idx++) {
+        const includeBody = images.length === 0 && idx === 0;
+        await sendOne(videos[idx].file, includeBody);
+      }
+
+      // Audios and others: send individually, include body only if none included yet
+      const includeBodyForFirstDoc = images.length === 0 && videos.length === 0;
+      let bodyUsed = includeBodyForFirstDoc;
+      for (let i = 0; i < audios.length; i++) {
+        await sendOne(audios[i].file, !bodyUsed && i === 0);
+        if (!bodyUsed && i === 0) bodyUsed = true;
+      }
+      for (let i = 0; i < others.length; i++) {
+        await sendOne(others[i].file, !bodyUsed && i === 0);
+        if (!bodyUsed && i === 0) bodyUsed = true;
+      }
+
+      clearSelectedFiles();
       onReset();
     } catch (error) {
-      console.error("File upload failed:", error);
-      toast.error("Failed to upload file");
+      console.error("Files upload failed:", error);
+      toast.error("Failed to upload files");
+    } finally {
+      setIsBulkUploading(false);
     }
   };
 
@@ -309,19 +402,21 @@ export function useFileUpload({
   }, []);
 
   return {
-    selectedFile: state.selectedFile,
-    mediaPreview: state.mediaPreview,
+    selectedItems: state.selectedItems,
+    totalSelectedSize,
     pendingPaste: state.pendingPaste,
     isDragActive,
-    isUploading: uploadMedia.isPending,
+    isUploading: uploadMedia.isPending || isBulkUploading,
     dropzoneProps: getRootProps(),
     inputProps: getInputProps(),
     fileInputRef,
     handleFileSelect,
     handleFileChange,
-    clearSelectedFile,
+    removeSelectedItem,
+    clearSelectedFiles,
     clearPendingPaste,
-    uploadSelectedFile,
+    uploadSelectedFiles,
     uploadPendingPaste,
+    MAX_TOTAL_SIZE,
   };
 }


### PR DESCRIPTION
This pull request adds support for selecting and previewing multiple files for upload in the media chat component, and improves the display of grouped media messages in chat history. It refactors file handling logic to work with multiple files, introduces new UI components for multi-file previews, and enhances the chat message list to group consecutive media messages from the same sender.

**Multi-file upload and preview support:**

* Added the new `MultiFilePreview` component to display selected files (images, videos, and others) with preview, total size, and removal options before upload. (`client/src/app/shared/components/mediaChatComponent/MultiFilePreview.tsx`)
* Refactored file upload logic in `MediaChatComponent` to support selecting, previewing, and clearing multiple files, including updating event handlers and input attributes. (`client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx`) [[1]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192L106-R108) [[2]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192L143-R152) [[3]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192L269-R277) [[4]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192R313)

**Grouped media message display:**

* Enhanced `ChatMessageList` to group consecutive image/video messages from the same sender within a short time window, displaying them together using the new `GroupedMediaMessage` component. (`client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx`, `client/src/app/shared/components/mediaChatComponent/GroupedMediaMessage.tsx`) [[1]](diffhunk://#diff-9e1be51e94abd8687b8b386089e97d72791ef9b69a71312dc0435186bbdf681eR41-R87) [[2]](diffhunk://#diff-9e1be51e94abd8687b8b386089e97d72791ef9b69a71312dc0435186bbdf681eL134-R312) [[3]](diffhunk://#diff-3536fb1fa4f06a0b65257629c8745cad5031b4a9a99096f0ee287df65f7b15b6R1-R64)

**UI and prop updates:**

* Removed the unused `hasFileAttached` prop from `ChatInput` and updated its file attachment button disabling logic to use permission and upload state instead. (`client/src/app/shared/components/mediaChatComponent/ChatInput.tsx`, `client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx`) [[1]](diffhunk://#diff-37499c49e4219d1b054938e14511bb76925abeda79064e87c3243db4998cbe03L14) [[2]](diffhunk://#diff-37499c49e4219d1b054938e14511bb76925abeda79064e87c3243db4998cbe03L27) [[3]](diffhunk://#diff-37499c49e4219d1b054938e14511bb76925abeda79064e87c3243db4998cbe03L93-R91) [[4]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192L286)

**Other improvements:**

* Improved code readability and maintainability by restructuring imports and extracting grouped media rendering logic into its own component. (`client/src/app/shared/components/mediaChatComponent/ChatMessageList.tsx`, `client/src/app/shared/components/mediaChatComponent/GroupedMediaMessage.tsx`) [[1]](diffhunk://#diff-9e1be51e94abd8687b8b386089e97d72791ef9b69a71312dc0435186bbdf681eL1-R16) [[2]](diffhunk://#diff-3536fb1fa4f06a0b65257629c8745cad5031b4a9a99096f0ee287df65f7b15b6R1-R64)

#46 