### PR TITLE
feat: implement message encryption at rest using AES-256-GCM

### DIFF
--- a/API/Program.cs
+++ b/API/Program.cs
@@ -27,6 +27,7 @@ using Resend;
 using Application.ChatRoomRoles.Validators;
 using Domain.Enums;
 using API.SignalR.EventHandlers;
+using Persistance.Security;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -130,6 +131,7 @@ builder.Services.AddAuthorization(opt =>
 });
 builder.Services.AddTransient<IAuthorizationHandler, IsAdminRequirementHandler>();
 builder.Services.AddTransient<IAuthorizationHandler, HasPermissionRequirementHandler>();
+MessageCrypto.Initialize(builder.Configuration);
 
 var clientAppOrigins = builder.Configuration["ClientAppUrl"]?
     .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);

--- a/API/appsettings.Development.json
+++ b/API/appsettings.Development.json
@@ -14,5 +14,6 @@
     "AccessKey": "minioadmin",
     "SecretKey": "minioadmin123",
     "BucketName": "media-files"
-  }
+  },
+  "MessageEncryptionKey": "dVrFWKGJwr8WokUnlRT5fMrsAcyPsMcs1Bcon2FmaXY="
 }

--- a/Persistance/AppDbContext.cs
+++ b/Persistance/AppDbContext.cs
@@ -2,6 +2,7 @@ using Domain;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Persistance.Security;
 
 namespace Persistance;
 
@@ -176,6 +177,10 @@ public class AppDbContext(DbContextOptions options) : IdentityDbContext<User>(op
         {
             x.HasKey(dm => dm.Id);
 
+            // Encrypt message body at rest
+            x.Property(dm => dm.Body)
+                .HasConversion(EncryptedStringConverter.Instance);
+
             x.HasOne(dm => dm.Sender)
                 .WithMany()
                 .HasForeignKey(dm => dm.SenderId)
@@ -219,6 +224,10 @@ public class AppDbContext(DbContextOptions options) : IdentityDbContext<User>(op
         // Reply relationship for chat room messages
         builder.Entity<Message>(x =>
         {
+            // Encrypt message body at rest
+            x.Property(m => m.Body)
+                .HasConversion(EncryptedStringConverter.Instance);
+
             x.HasOne(m => m.ReplyToMessage)
                 .WithMany()
                 .HasForeignKey(m => m.ReplyToMessageId)

--- a/Persistance/Security/EncryptedStringConverter.cs
+++ b/Persistance/Security/EncryptedStringConverter.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Persistance.Security;
+
+public sealed class EncryptedStringConverter : ValueConverter<string, string>
+{
+    public static readonly EncryptedStringConverter Instance = new();
+
+    private EncryptedStringConverter()
+        : base(
+            v => v == null ? string.Empty : MessageCrypto.Encrypt(v),
+            v => string.IsNullOrEmpty(v) ? v : MessageCrypto.Decrypt(v))
+    { }
+}

--- a/Persistance/Security/MessageCrypto.cs
+++ b/Persistance/Security/MessageCrypto.cs
@@ -22,12 +22,11 @@ public static class MessageCrypto
         {
             if (_key != null) return;
 
-            // Prefer appsettings: MessageEncryption:Key
             var keyString = configuration["MessageEncryptionKey"];
 
             if (string.IsNullOrWhiteSpace(keyString))
             {
-                throw new InvalidOperationException($"Missing required configuration 'MessageEncryption:Key' (or environment variable). Provide a 32-byte (256-bit) key before running the API.");
+                throw new InvalidOperationException($"Missing required configuration 'MessageEncryptionKey' (or environment variable). Provide a 32-byte (256-bit) key before running the API.");
             }
 
             _key = TryDecodeBase64(keyString) ?? TryDecodeHex(keyString);

--- a/Persistance/Security/MessageCrypto.cs
+++ b/Persistance/Security/MessageCrypto.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.Configuration;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Persistance.Security;
+
+public static class MessageCrypto
+{
+    private const string Prefix = "enc:v1:";
+
+    // AES-GCM parameters
+    private const int NonceSize = 12; // 96-bit nonce per NIST recommendation
+    private const int TagSize = 16;   // 128-bit tag
+
+    private static byte[]? _key;
+    private static readonly object _lock = new();
+
+    public static void Initialize(IConfiguration configuration)
+    {
+        if (_key != null) return;
+        lock (_lock)
+        {
+            if (_key != null) return;
+
+            // Prefer appsettings: MessageEncryption:Key
+            var keyString = configuration["MessageEncryptionKey"];
+
+            if (string.IsNullOrWhiteSpace(keyString))
+            {
+                throw new InvalidOperationException($"Missing required configuration 'MessageEncryption:Key' (or environment variable). Provide a 32-byte (256-bit) key before running the API.");
+            }
+
+            _key = TryDecodeBase64(keyString) ?? TryDecodeHex(keyString);
+            if (_key is null || _key.Length != 32)
+            {
+                throw new InvalidOperationException($"Invalid encryption key. Provide 32 bytes (256-bit) key as Base64 or Hex in 'MessageEncryption:Key'.");
+            }
+        }
+    }
+
+    public static void EnsureInitialized()
+    {
+        if (_key != null) return;
+        throw new InvalidOperationException("MessageCrypto is not initialized. Call MessageCrypto.Initialize(configuration) during startup.");
+    }
+
+    public static string Encrypt(string plaintext)
+    {
+        EnsureInitialized();
+        if (plaintext is null) return string.Empty;
+
+        var plainBytes = Encoding.UTF8.GetBytes(plaintext);
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var cipher = new byte[plainBytes.Length];
+        var tag = new byte[TagSize];
+
+        using var aes = new AesGcm(_key!, TagSize);
+        aes.Encrypt(nonce, plainBytes, cipher, tag);
+
+        var payload = new byte[NonceSize + TagSize + cipher.Length];
+        Buffer.BlockCopy(nonce, 0, payload, 0, NonceSize);
+        Buffer.BlockCopy(tag, 0, payload, NonceSize, TagSize);
+        Buffer.BlockCopy(cipher, 0, payload, NonceSize + TagSize, cipher.Length);
+
+        return Prefix + Convert.ToBase64String(payload);
+    }
+
+    public static string Decrypt(string stored)
+    {
+        EnsureInitialized();
+        if (string.IsNullOrEmpty(stored)) return stored;
+
+        if (!stored.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            return stored;
+        }
+
+        var b64 = stored.Substring(Prefix.Length);
+        var payload = Convert.FromBase64String(b64);
+        if (payload.Length < NonceSize + TagSize)
+        {
+            throw new FormatException("Encrypted payload too short.");
+        }
+
+        var nonce = new byte[NonceSize];
+        var tag = new byte[TagSize];
+        var cipher = new byte[payload.Length - NonceSize - TagSize];
+
+        Buffer.BlockCopy(payload, 0, nonce, 0, NonceSize);
+        Buffer.BlockCopy(payload, NonceSize, tag, 0, TagSize);
+        Buffer.BlockCopy(payload, NonceSize + TagSize, cipher, 0, cipher.Length);
+
+        var plain = new byte[cipher.Length];
+        using var aes = new AesGcm(_key!, TagSize);
+        aes.Decrypt(nonce, cipher, tag, plain);
+        return Encoding.UTF8.GetString(plain);
+    }
+
+    private static byte[]? TryDecodeBase64(string input)
+    {
+        try { return Convert.FromBase64String(input.Trim()); }
+        catch { return null; }
+    }
+
+    private static byte[]? TryDecodeHex(string input)
+    {
+        try
+        {
+            var s = input.Trim();
+            if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) s = s[2..];
+            if (s.Length % 2 != 0) return null;
+            var bytes = new byte[s.Length / 2];
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = Convert.ToByte(s.Substring(i * 2, 2), 16);
+            }
+            return bytes;
+        }
+        catch { return null; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -174,3 +174,20 @@ Notes
 - Prioritize code quality and learning over speed
 - Small, reviewable changes win
 - Prefer refactoring and tests to keep the codebase welcoming
+
+Message Encryption (at rest)
+
+- Messages are encrypted at rest using AES-256-GCM via an EF Core value converter.
+- Encrypted fields:
+  - `Domain/Message.cs: Body`
+  - `Domain/DirectMessage.cs: Body`
+- Configure a 256-bit key via environment variable before starting the API:
+  - Variable: `MESSAGE_ENCRYPTION_KEY`
+  - Provide 32 bytes as Base64 or Hex (e.g., `0x...`).
+- Generate a random key (PowerShell):
+  - `$bytes = New-Object 'Byte[]' 32; [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes); [Convert]::ToBase64String($bytes)`
+  - Persist for your user session: `setx MESSAGE_ENCRYPTION_KEY <Base64Key>` (restart shell)
+- Behavior & migration notes:
+  - New/updated records are stored encrypted with prefix `enc:v1:`.
+  - Existing plaintext rows are read as-is and remain until modified.
+  - For backfill, run a one-time job that reads and re-saves messages to trigger encryption.

--- a/client/src/app/layout/SideNav/DefaultSidebarContent.tsx
+++ b/client/src/app/layout/SideNav/DefaultSidebarContent.tsx
@@ -16,24 +16,24 @@ import { useDirectChats } from "../../../lib/hooks/useDirectChats";
 import { useMemo, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useStore } from "../../../lib/hooks/useStore";
+import { useFriends } from "../../../lib/hooks/useFriends";
 
 const DefaultSidebarContent = observer(function DefaultSidebarContent() {
   const location = useLocation();
   const [query, setQuery] = useState("");
   const { directChats } = useDirectChats();
   const { messagesNotificationsStore } = useStore();
-  const isFriendsRoute = location.pathname.startsWith("/friends");
+  const { friendRequests } = useFriends();
+  const friendInvitesCount = friendRequests?.received?.length || 0;
 
   const filteredChats = useMemo(() => {
     const q = query.trim().toLowerCase();
-    const base = (directChats ?? []).filter((c) =>
-      isFriendsRoute ? c.canSendMessages : true
-    );
+    const base = directChats ?? [];
     if (!q) return base;
     return base.filter((c) =>
       (c.otherUserDisplayName ?? "").toLowerCase().includes(q)
     );
-  }, [directChats, query, isFriendsRoute]);
+  }, [directChats, query]);
 
   return (
     <>
@@ -53,7 +53,24 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
           sx={{ borderRadius: 1, mx: 1, my: 0.5 }}
         >
           <ListItemIcon>
-            <PeopleAlt sx={{ color: "white" }} />
+            <Badge
+              color="success"
+              overlap="rectangular"
+              anchorOrigin={{ vertical: "top", horizontal: "left" }}
+              badgeContent={friendInvitesCount}
+              invisible={!friendInvitesCount}
+              max={99}
+              sx={{
+                "& .MuiBadge-badge": {
+                  minWidth: 18,
+                  height: 18,
+                  fontSize: 10,
+                  fontWeight: 700,
+                },
+              }}
+            >
+              <PeopleAlt sx={{ color: "white" }} />
+            </Badge>
           </ListItemIcon>
           <ListItemText
             primary={<Typography color="white">Friends</Typography>}
@@ -73,13 +90,19 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
           {filteredChats.map((chat) => {
             const unreadCount =
               messagesNotificationsStore.directUnreadByChat.get(chat.id) ?? 0;
+            const isReadOnly = !chat.canSendMessages;
 
             return (
               <ListItemButton
                 key={chat.id}
                 component={Link}
                 to={`/direct-chats/${chat.otherUserSlug}`}
-                sx={{ borderRadius: 1, mx: 1, my: 0.2 }}
+                sx={{
+                  borderRadius: 1,
+                  mx: 1,
+                  my: 0.2,
+                  opacity: isReadOnly ? 0.6 : 1,
+                }}
                 selected={
                   location.pathname === `/direct-chats/${chat.otherUserSlug}`
                 }
@@ -105,6 +128,9 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
                       src={chat.otherUserImageUrl}
                       alt={chat.otherUserDisplayName}
                       status={chat.status || "Offline"}
+                      containerSx={
+                        isReadOnly ? { filter: "grayscale(100%)" } : undefined
+                      }
                     >
                       {chat.otherUserDisplayName?.charAt(0).toUpperCase()}
                     </AvatarWithStatus>
@@ -113,7 +139,7 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
                 <ListItemText
                   primary={
                     <Typography
-                      color="white"
+                      color={isReadOnly ? "text.secondary" : "white"}
                       fontWeight={unreadCount ? 700 : undefined}
                     >
                       {chat.otherUserDisplayName}

--- a/client/src/app/layout/SideNav/SideNav.tsx
+++ b/client/src/app/layout/SideNav/SideNav.tsx
@@ -14,6 +14,7 @@ import { useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useChatRooms } from "../../../lib/hooks/useChatRooms";
 import { useStore } from "../../../lib/hooks/useStore";
+import { useFriends } from "../../../lib/hooks/useFriends";
 
 const SideNav = observer(function SideNav() {
   const {
@@ -95,6 +96,8 @@ const SideNav = observer(function SideNav() {
   }, [fetchNextPage, hasNextPage]);
 
   const totalDirectUnread = messagesNotificationsStore.totalDirectUnread;
+  const { friendRequests } = useFriends();
+  const friendInvitesCount = friendRequests?.received?.length || 0;
 
   return (
     <Box
@@ -131,11 +134,13 @@ const SideNav = observer(function SideNav() {
           }}
           className="rc-server-btn"
         >
+          {/* Green top-left badge for friend invites */}
           <Badge
-            color="error"
+            color="success"
             overlap="rectangular"
-            badgeContent={totalDirectUnread}
-            invisible={!totalDirectUnread}
+            anchorOrigin={{ vertical: "top", horizontal: "left" }}
+            badgeContent={friendInvitesCount}
+            invisible={!friendInvitesCount}
             max={99}
             sx={{
               "& .MuiBadge-badge": {
@@ -144,11 +149,28 @@ const SideNav = observer(function SideNav() {
                 minWidth: 20,
                 height: 20,
                 borderRadius: "999px",
-                px: 0.75,
               },
             }}
           >
-            <Forum />
+            {/* Red top-right badge for unread direct messages */}
+            <Badge
+              color="error"
+              overlap="rectangular"
+              badgeContent={totalDirectUnread}
+              invisible={!totalDirectUnread}
+              max={99}
+              sx={{
+                "& .MuiBadge-badge": {
+                  fontSize: 11,
+                  fontWeight: 700,
+                  minWidth: 20,
+                  height: 20,
+                  borderRadius: "999px",
+                },
+              }}
+            >
+              <Forum />
+            </Badge>
           </Badge>
         </IconButton>
       </Tooltip>
@@ -234,7 +256,6 @@ const SideNav = observer(function SideNav() {
                           minWidth: 22,
                           height: 20,
                           borderRadius: "999px",
-                          boxShadow: "0 0 0 2px #1e1f24",
                           right: 2,
                           top: 2,
                           px: 0.75,

--- a/client/src/app/shared/components/mediaChatComponent/ChatInput.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { TextField, IconButton, CircularProgress, Box } from "@mui/material";
 import { AttachFile, Send } from "@mui/icons-material";
 import { useForm, type FieldValues } from "react-hook-form";
+import { useRef, useState } from "react";
 import EmojiPickerComponent from "../EmojiPicker";
 
 interface ChatInputProps {
@@ -29,10 +30,13 @@ export default function ChatInput({
   hasAttachment = false,
 }: ChatInputProps) {
   const { register, handleSubmit, reset, setValue, watch } = useForm();
+  const clickLockRef = useRef(false);
+  const [localSending, setLocalSending] = useState(false);
   const currentMessage = watch("body") || "";
   const canSend =
     hasPermission &&
     !isSubmitting &&
+    !localSending &&
     !isUploading &&
     ((currentMessage?.trim?.().length ?? 0) > 0 || hasAttachment);
 
@@ -103,7 +107,18 @@ export default function ChatInput({
                   <IconButton
                     aria-label="Send message"
                     color="primary"
-                    onClick={() => handleSubmit(handleFormSubmit)()}
+                    onClick={async () => {
+                      if (clickLockRef.current) return;
+                      clickLockRef.current = true;
+                      setLocalSending(true);
+                      try {
+                        const doSubmit = handleSubmit(handleFormSubmit);
+                        await Promise.resolve(doSubmit());
+                      } finally {
+                        setLocalSending(false);
+                        clickLockRef.current = false;
+                      }
+                    }}
                     disabled={!canSend}
                     size="small"
                   >
@@ -137,7 +152,7 @@ export default function ChatInput({
       {/* Default emoji on the right of the input */}
       <IconButton
         onClick={() => handleDefaultEmoji(defaultEmoji)}
-        disabled={isSubmitting || isUploading}
+        disabled={!hasPermission || isSubmitting || isUploading}
         size="small"
         title={`Quick react with ${defaultEmoji}`}
         sx={{

--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -40,6 +40,7 @@ interface MediaChatComponentProps {
   userPermissions?: ReturnType<
     typeof useChatRoomRolesRealtime
   >["userPermissions"];
+  directCanSend?: boolean;
 }
 
 const MediaChatComponent = observer(function MediaChatComponent({
@@ -50,6 +51,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
   chatRoomId,
   directChatId,
   userPermissions,
+  directCanSend,
 }: MediaChatComponentProps) {
   const [imageDialog, setImageDialog] = useState<{
     open: boolean;
@@ -387,11 +389,11 @@ const MediaChatComponent = observer(function MediaChatComponent({
                 hasAttachment={hasFileAttached}
                 hasPermission={
                   chatRoomId === undefined
-                    ? true
-                    : userPermissions &&
-                      userPermissions[CHATROOM_PERMISSIONS.SendMessages]
-                    ? true
-                    : false
+                    ? directCanSend ?? true
+                    : !!(
+                        userPermissions &&
+                        userPermissions[CHATROOM_PERMISSIONS.SendMessages]
+                      )
                 }
                 placeholder={
                   hasFileAttached

--- a/client/src/features/directChats/DirectChatDetails.tsx
+++ b/client/src/features/directChats/DirectChatDetails.tsx
@@ -177,6 +177,7 @@ const DirectChatDetails = observer(function DirectChatDetails() {
             chatRoomId={undefined}
             directChatId={directChatId}
             userPermissions={undefined}
+            directCanSend={currentChat.canSendMessages}
           />
         </Box>
       </Box>

--- a/client/src/features/friends/Friends.tsx
+++ b/client/src/features/friends/Friends.tsx
@@ -120,7 +120,6 @@ export default function Friends() {
   const tabs: { key: string; label: React.ReactNode }[] = [
     { key: "online", label: `Online (${onlineCount})` },
     { key: "all", label: `All (${allCount})` },
-    { key: "add", label: "Add Friend" },
   ];
   if (pendingCount > 0)
     tabs.push({
@@ -140,6 +139,8 @@ export default function Friends() {
         </Box>
       ),
     });
+
+  tabs.push({ key: "add", label: "Add Friend" });
 
   const indexToKey = tabs.map((t) => t.key);
 


### PR DESCRIPTION
Closes #100
This pull request introduces message encryption at rest for chat messages, improves the user interface to highlight friend invites, and enhances input handling in chat components. The most significant changes are grouped below.

### Message Encryption (Backend & Configuration)
* Added AES-256-GCM encryption for message bodies in both `Message` and `DirectMessage` entities using the new `EncryptedStringConverter` and `MessageCrypto` utility. This ensures messages are encrypted before being stored in the database and decrypted transparently when read. [[1]](diffhunk://#diff-d1bdb012a1b04755e4998ca5ca5b55f72bc8a3f4a020ce84814178727790515eR1-R14) [[2]](diffhunk://#diff-963f94adb8db8c0a5affa73803383b67ccb16695516261837e9bff43eb6e4e5bR1-R121) [[3]](diffhunk://#diff-8dc29cf1842a88db4f001d777569e7f6e7ce6974bfbdd819a963c4011c677373R180-R183) [[4]](diffhunk://#diff-8dc29cf1842a88db4f001d777569e7f6e7ce6974bfbdd819a963c4011c677373R227-R230)
* Integrated encryption key configuration via `appsettings.Development.json` and documented setup and migration notes in `README.md`, including how to generate and provide the key as an environment variable. [[1]](diffhunk://#diff-da26925c59a665d59d478c8a67c46ace61e6c1d94679a65911e0cc50bf096ed0L17-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177-R193)

### Friend Invite Badges (UI Enhancement)
* Added green badge indicators to the sidebar and friends list to show the count of incoming friend requests, improving visibility for users. [[1]](diffhunk://#diff-b5c679ae8d486f2f6f6ff817e0c523598d728085acba8bf469435b716d4d827cR56-R73) [[2]](diffhunk://#diff-5fc8c3db18e68d4e81caa7921f8d500f728cb3341398c22c6517489f2d1dc9b9R137-R155)
* Updated sidebar logic to fetch and display friend invite counts using the `useFriends` hook. [[1]](diffhunk://#diff-b5c679ae8d486f2f6f6ff817e0c523598d728085acba8bf469435b716d4d827cR19-R36) [[2]](diffhunk://#diff-5fc8c3db18e68d4e81caa7921f8d500f728cb3341398c22c6517489f2d1dc9b9R17) [[3]](diffhunk://#diff-5fc8c3db18e68d4e81caa7921f8d500f728cb3341398c22c6517489f2d1dc9b9R99-R100)

### Direct Chat List Improvements
* Refined the appearance of read-only direct chats by applying opacity and grayscale styling, and adjusted text color to indicate restricted messaging. [[1]](diffhunk://#diff-b5c679ae8d486f2f6f6ff817e0c523598d728085acba8bf469435b716d4d827cR93-R105) [[2]](diffhunk://#diff-b5c679ae8d486f2f6f6ff817e0c523598d728085acba8bf469435b716d4d827cR131-R133) [[3]](diffhunk://#diff-b5c679ae8d486f2f6f6ff817e0c523598d728085acba8bf469435b716d4d827cL116-R142)
* Simplified chat filtering logic to remove unnecessary route-based filtering.

### Chat Input UX Fixes
* Prevented duplicate message sends by introducing a local sending lock and disabling the send button during submission. [[1]](diffhunk://#diff-37499c49e4219d1b054938e14511bb76925abeda79064e87c3243db4998cbe03R33-R39) [[2]](diffhunk://#diff-37499c49e4219d1b054938e14511bb76925abeda79064e87c3243db4998cbe03L106-R121)
* Disabled quick emoji reactions when the user lacks permission to send messages.

### Component Props Extension
* Extended `MediaChatComponent` props to support direct messaging permission checks, enabling more accurate UI and permission handling. [[1]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192R43) [[2]](diffhunk://#diff-689e8538accffab85f41ccac1b0c400c2dfec0343f5284bc5d95c2c0367a4192R54)