### PR TITLE
K u r c/issue104

### DIFF
--- a/API/Controllers/ChatRoomsController.cs
+++ b/API/Controllers/ChatRoomsController.cs
@@ -100,9 +100,11 @@ public class ChatRoomsController : BaseApiController
 
     [HttpPost("{id}/generateInviteLink")]
     [Authorize(Policy = ChatRoomPermissions.CreateInviteLinks)]
-    public async Task<ActionResult<string>> GenerateInviteLink(string id)
+    public async Task<ActionResult<string>> GenerateInviteLink(string id, [FromBody] GenerateInviteLink.Command? command)
     {
-        return HandleResult(await Mediator.Send(new GenerateInviteLink.Command { Id = id }));
+        var resolvedCommand = command ?? new GenerateInviteLink.Command { Id = id };
+        resolvedCommand.Id = id;
+        return HandleResult(await Mediator.Send(resolvedCommand));
     }
 
     [HttpPost("{id}/invites")]

--- a/API/Controllers/EncryptedDirectChatsController.cs
+++ b/API/Controllers/EncryptedDirectChatsController.cs
@@ -1,0 +1,38 @@
+﻿using Application.EncryptedDirectChats.Queries;
+using Application.EncryptedDirectMessages.Commands;
+using Application.EncryptedDirectMessages.Queries;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers;
+
+public class EncryptedDirectChatsController : BaseApiController
+{
+    [HttpGet]
+    public async Task<ActionResult> GetEncryptedDirectChats()
+    {
+        return HandleResult(await Mediator.Send(new GetEncryptedDirectChats.Query()));
+    }
+
+    [HttpGet("{encryptedDirectChatId}/messages")]
+    public async Task<ActionResult> GetEncryptedDirectMessages(
+        string encryptedDirectChatId,
+        [FromQuery] DateTime? cursor = null,
+        [FromQuery] int pageSize = 20)
+    {
+        return HandleResult(await Mediator.Send(new GetEncryptedDirectMessages.Query
+        {
+            EncryptedDirectChatId = encryptedDirectChatId,
+            Cursor = cursor,
+            PageSize = pageSize
+        }));
+    }
+
+    [HttpPost("{encryptedDirectChatId}/messages")]
+    public async Task<ActionResult> SendEncryptedDirectMessage(
+        string encryptedDirectChatId,
+        [FromBody] SendEncryptedDirectMessage.Command command)
+    {
+        command.EncryptedDirectChatId = encryptedDirectChatId;
+        return HandleResult(await Mediator.Send(command));
+    }
+}

--- a/API/Controllers/MediaController.cs
+++ b/API/Controllers/MediaController.cs
@@ -4,7 +4,6 @@ using Application.Media.Commands;
 using Application.Media.DTOs;
 using Application.Media.Helpers;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Persistance;
@@ -66,11 +65,19 @@ public class MediaController(
             {
                 if (mediaFile.UploadedById != user.Id)
                 {
-                    var hasAccess = await context.DirectMessages
+                    var hasAccessDirect = await context.DirectMessages
                         .AnyAsync(dm => dm.MediaPublicId == mediaFile.PublicId &&
                                         (dm.DirectChat.User1Id == user.Id || dm.DirectChat.User2Id == user.Id));
 
-                    if (!hasAccess) return Forbid();
+                    var hasAccessEncrypted = await context.EncryptedDirectMessages
+                        .AnyAsync(
+                            dm =>
+                            dm.EncryptedDirectChat.User1Id == user.Id
+                            ||
+                            dm.EncryptedDirectChat.User2Id == user.Id
+                        );
+
+                    if (!hasAccessDirect && !hasAccessEncrypted) return Forbid();
                 }
             }
         }

--- a/API/Controllers/NotificationsController.cs
+++ b/API/Controllers/NotificationsController.cs
@@ -1,4 +1,4 @@
-using Application.Notifications.Commands;
+﻿using Application.Notifications.Commands;
 using Application.Notifications.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -31,4 +31,14 @@ public class NotificationsController : BaseApiController
             DirectChatId = directChatId,
         }));
     }
+
+    [HttpPost("encrypted-direct-chats/{encryptedDirectChatId}/read")]
+    public async Task<IActionResult> MarkEncryptedDirectChatRead(string encryptedDirectChatId)
+    {
+        return HandleResult(await Mediator.Send(new MarkEncryptedDirectChatNotificationsRead.Command
+        {
+            EncryptedDirectChatId = encryptedDirectChatId,
+        }));
+    }
+
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -92,6 +92,7 @@ builder.Services.AddScoped<IFriendsNotificationService, FriendsNotificationServi
 builder.Services.AddScoped<IUserStatusService, UserStatusService>();
 builder.Services.AddScoped<IStatusNotificationService, StatusNotificationService>();
 builder.Services.AddScoped<IDirectMessagesNotificationService, DirectMessagesNotificationService>();
+builder.Services.AddScoped<IEncryptedDirectMessagesNotificationService, EncryptedDirectMessagesNotificationService>();
 builder.Services.AddScoped<IChatRoomsNotificationService, ChatRoomsNotificationService>();
 builder.Services.AddAutoMapper(typeof(MappingProfiles).Assembly);
 builder.Services.AddValidatorsFromAssemblyContaining<CreateChatRoomValidator>();
@@ -158,6 +159,8 @@ app.MapGroup("api").MapIdentityApi<User>();
 app.MapHub<MessageHub>("/messages");
 app.MapHub<FriendsHub>("/friends");
 app.MapHub<DirectMessageHub>("/direct-messages");
+app.MapHub<EncryptedDirectMessageHub>("/encrypted-direct-messages");
+app.MapHub<EncryptedMessageHub>("/encrypted-messages");
 app.MapHub<StatusHub>("/status");
 app.MapHub<ChatRoomRolesHub>("/chatroom-roles");
 app.MapHub<ChatRoomsProfileUpdateHub>("/chatroom-image-update");

--- a/API/Services/EncryptedDirectMessagesNotificationService.cs
+++ b/API/Services/EncryptedDirectMessagesNotificationService.cs
@@ -1,0 +1,81 @@
+﻿using Application.EncryptedDirectMessages.DTOs;
+using Application.Interfaces;
+using API.SignalR;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace API.Services;
+
+public class EncryptedDirectMessagesNotificationService(
+    IHubContext<EncryptedMessageHub> encryptedMessageHubContext,
+    IHubContext<EncryptedDirectMessageHub> encryptedDirectMessageHubContext,
+    AppDbContext context
+) : IEncryptedDirectMessagesNotificationService
+{
+    public async Task NotifyNewMessage(string encryptedDirectChatId, EncryptedDirectMessageDto message, bool broadcastToEncryptedChat = false)
+    {
+        var chatParticipants = await context.EncryptedDirectChats
+            .Where(dc => dc.Id == encryptedDirectChatId)
+            .Select(dc => new { dc.User1Id, dc.User2Id })
+            .FirstOrDefaultAsync();
+
+        if (chatParticipants is null) return;
+
+        var participantIds = new[] { chatParticipants.User1Id, chatParticipants.User2Id }
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct()
+            .ToList();
+
+        if (participantIds.Count == 0) return;
+
+        var recipientsToIncrement = participantIds
+            .Where(id => id != message.SenderId)
+            .ToList();
+
+        if (recipientsToIncrement.Count > 0)
+        {
+            var existingCounters = await context.EncryptedDirectChatNotifications
+                .Where(n => n.EncryptedDirectChatId == encryptedDirectChatId && recipientsToIncrement.Contains(n.UserId))
+                .ToListAsync();
+
+            foreach (var userId in recipientsToIncrement)
+            {
+                var counter = existingCounters.FirstOrDefault(n => n.UserId == userId);
+                if (counter is null)
+                {
+                    counter = new Domain.EncryptedDirectChatNotification
+                    {
+                        Id = Guid.NewGuid(),
+                        EncryptedDirectChatId = encryptedDirectChatId,
+                        UserId = userId,
+                    };
+                    context.EncryptedDirectChatNotifications.Add(counter);
+                }
+
+                counter.UnreadCount += 1;
+                counter.UpdatedAt = DateTime.UtcNow;
+            }
+
+            await context.SaveChangesAsync();
+        }
+
+        if (broadcastToEncryptedChat)
+        {
+            await encryptedDirectMessageHubContext.Clients.Group(encryptedDirectChatId)
+                .SendAsync("ReceiveEncryptedDirectMessage", message);
+        }
+
+        var payload = new
+        {
+            encryptedDirectChatId,
+            message,
+        };
+
+        foreach (var userId in participantIds)
+        {
+            await encryptedMessageHubContext.Clients.Group($"encrypted-user-{userId}")
+                .SendAsync("EncryptedDirectChatUpdated", payload);
+        }
+    }
+}

--- a/API/SignalR/EncryptedDirectMessageHub.cs
+++ b/API/SignalR/EncryptedDirectMessageHub.cs
@@ -1,0 +1,115 @@
+﻿using Application.Core;
+using Application.EncryptedDirectMessages.Commands;
+using Application.EncryptedDirectMessages.Queries;
+using Application.Messages.SignalR;
+using Application.Interfaces;
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+
+namespace API.SignalR;
+
+public class EncryptedDirectMessageHub(
+    IMediator mediator,
+    IEncryptedDirectMessagesNotificationService notificationService
+) : Hub
+{
+    public async Task SendEncryptedMessage(SendEncryptedDirectMessage.Command command)
+    {
+        try
+        {
+            var result = await mediator.Send(command);
+
+            if (!result.IsSuccess || result.Value == null)
+            {
+                throw new SendMessageHubException(result.Error ?? "Failed to send encrypted message", result.Code);
+            }
+
+            await Clients.Group(command.EncryptedDirectChatId)
+                .SendAsync("ReceiveEncryptedDirectMessage", result.Value);
+
+            await notificationService.NotifyNewMessage(command.EncryptedDirectChatId, result.Value);
+        }
+        catch (SendMessageHubException hubException)
+        {
+            if (hubException.ErrorCode == ErrorCodes.WillNotBeProcessed) return;
+
+            await Clients.Caller.SendAsync("ReceiveError", hubException.ErrorCode, hubException.Message);
+        }
+    }
+
+    public async Task ToggleEncryptedMessageReaction(string encryptedDirectChatId, string encryptedDirectMessageId, string emoji)
+    {
+        try
+        {
+            var reaction = await mediator.Send(new ToggleEncryptedDirectMessageReaction.Command
+            {
+                EncryptedDirectChatId = encryptedDirectChatId,
+                EncryptedDirectMessageId = encryptedDirectMessageId,
+                Emoji = emoji
+            });
+
+            if (reaction.IsSuccess && reaction.Value is not null)
+            {
+                await Clients.OthersInGroup(encryptedDirectChatId)
+                    .SendAsync("ReceiveEncryptedReactionUpdate", reaction.Value);
+            }
+            else if (!reaction.IsSuccess)
+            {
+                await Clients.Caller.SendAsync("ReceiveError", reaction.Code, reaction.Error);
+            }
+        }
+        catch
+        {
+            await Clients.Caller.SendAsync("ReceiveError", 500, "Failed to toggle reaction");
+        }
+    }
+
+    public async Task LoadMoreEncryptedMessages(string encryptedDirectChatId, DateTime? cursor, int pageSize = 20)
+    {
+        try
+        {
+            var result = await mediator.Send(new GetEncryptedDirectMessages.Query
+            {
+                EncryptedDirectChatId = encryptedDirectChatId,
+                Cursor = cursor,
+                PageSize = pageSize
+            });
+
+            if (result.Value != null)
+            {
+                await Clients.Caller.SendAsync("ReceiveOlderEncryptedMessages", result.Value);
+            }
+        }
+        catch
+        {
+            await Clients.Caller.SendAsync("ReceiveError", 500, "Failed to load more encrypted messages");
+        }
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        var httpContext = Context.GetHttpContext();
+        var chatId = httpContext?.Request.Query["encryptedDirectChatId"];
+
+        if (string.IsNullOrEmpty(chatId))
+        {
+            throw new HubException("No encrypted direct chat id provided");
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, chatId!);
+
+        var initialPageSize =
+            int.TryParse(httpContext?.Request.Query["initialPageSize"], out var size) ? size : 20;
+
+        var result = await mediator.Send(new GetEncryptedDirectMessages.Query
+        {
+            EncryptedDirectChatId = chatId!,
+            PageSize = initialPageSize
+        });
+
+        if (result.Value != null)
+        {
+            await Clients.Caller.SendAsync("LoadEncryptedDirectMessages", result.Value);
+        }
+    }
+}

--- a/API/SignalR/EncryptedMessageHub.cs
+++ b/API/SignalR/EncryptedMessageHub.cs
@@ -1,0 +1,16 @@
+﻿using Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace API.SignalR;
+
+[Authorize]
+public class EncryptedMessageHub(IUserAccessor userAccessor) : Hub
+{
+    public override async Task OnConnectedAsync()
+    {
+        var user = await userAccessor.GetUserAsync();
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"encrypted-user-{user.Id}");
+        await base.OnConnectedAsync();
+    }
+}

--- a/Application/ChatRooms/Commands/CreateInvite.cs
+++ b/Application/ChatRooms/Commands/CreateInvite.cs
@@ -48,6 +48,8 @@ public class CreateInvite
                 ? DateTime.UtcNow.AddMinutes(effectiveExpiryMinutes)
                 : (DateTime?)null;
 
+            var maxUses = string.IsNullOrEmpty(request.AllowedUserId) ? request.MaxUses : 1;
+
             var invite = new Domain.ChatRoomInvite
             {
                 Id = Guid.NewGuid().ToString(),
@@ -55,7 +57,7 @@ public class CreateInvite
                 CreatedByUserId = user.Id,
                 Secret = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16)),
                 AllowedUserId = request.AllowedUserId,
-                MaxUses = request.MaxUses,
+                MaxUses = maxUses,
                 ExpiresAt = expiresAt,
                 CreatedAt = DateTime.UtcNow
             };

--- a/Application/ChatRooms/Commands/GenerateInviteLink.cs
+++ b/Application/ChatRooms/Commands/GenerateInviteLink.cs
@@ -1,5 +1,8 @@
+using System.Security.Cryptography;
+using System.Text;
 using Application.Core;
 using Application.Interfaces;
+using Domain;
 using MediatR;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
@@ -12,16 +15,21 @@ public class GenerateInviteLink
 {
     public class Command : IRequest<Result<string>>
     {
-        public required string Id { get; set; }
+        public string Id { get; set; } = string.Empty;
+        public int? MaxUses { get; set; }
+        public int? ExpiresInMinutes { get; set; }
     }
 
     public class Handler(
-        IConfiguration configuration,
-        AppDbContext context)
+        AppDbContext context,
+        IUserAccessor userAccessor,
+        IConfiguration configuration)
         : IRequestHandler<Command, Result<string>>
     {
         public async Task<Result<string>> Handle(Command request, CancellationToken cancellationToken)
         {
+            var user = await userAccessor.GetUserAsync();
+
             var chatRoom = await context.ChatRooms
                 .AsNoTracking()
                 .FirstOrDefaultAsync(x => x.Id == request.Id || x.Slug == request.Id, cancellationToken);
@@ -31,10 +39,31 @@ public class GenerateInviteLink
                 return Result<string>.Failure("Chat room not found", 404);
             }
 
-            var expires = DateTime.UtcNow.AddMinutes(10);
-            var token = Convert.ToBase64String(Guid.NewGuid().ToByteArray());
-            var joinToken = $"{chatRoom.Id}:{token}:{expires:o}";
-            var encodedToken = WebEncoders.Base64UrlEncode(System.Text.Encoding.UTF8.GetBytes(joinToken));
+            var effectiveExpiryMinutes = request.ExpiresInMinutes ?? 10;
+            var expiresAt = effectiveExpiryMinutes > 0
+                ? DateTime.UtcNow.AddMinutes(effectiveExpiryMinutes)
+                : (DateTime?)null;
+
+            var invite = new ChatRoomInvite
+            {
+                Id = Guid.NewGuid().ToString(),
+                ChatRoomId = chatRoom.Id,
+                CreatedByUserId = user.Id,
+                Secret = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16)),
+                MaxUses = request.MaxUses,
+                ExpiresAt = expiresAt,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            context.ChatRoomInvites.Add(invite);
+            var saved = await context.SaveChangesAsync(cancellationToken) > 0;
+            if (!saved)
+            {
+                return Result<string>.Failure("Failed to create invite", 400);
+            }
+
+            var tokenPayload = $"{invite.Id}:{invite.Secret}";
+            var encodedToken = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(tokenPayload));
 
             var clientUrl = configuration["ClientAppUrl"];
             if (string.IsNullOrEmpty(clientUrl))

--- a/Application/ChatRooms/Commands/JoinChatRoom.cs
+++ b/Application/ChatRooms/Commands/JoinChatRoom.cs
@@ -6,6 +6,7 @@ using MediatR;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Persistance;
+using System.Linq;
 
 namespace Application.ChatRooms.Commands;
 
@@ -61,10 +62,11 @@ public class JoinChatRoom
                     chatRoomIdFromToken = invite.ChatRoomId;
                 }
                 // Legacy format: chatRoomId:randomToken:expires
-                else if (parts.Length == 3)
+                else if (parts.Length >= 3)
                 {
                     chatRoomIdFromToken = parts[0];
-                    legacyExpiry = DateTime.Parse(parts[2], null, System.Globalization.DateTimeStyles.RoundtripKind);
+                    var expiryString = string.Join(':', parts.Skip(2));
+                    legacyExpiry = DateTime.Parse(expiryString, null, System.Globalization.DateTimeStyles.RoundtripKind);
                 }
                 else
                 {
@@ -132,6 +134,11 @@ public class JoinChatRoom
                 if (!string.IsNullOrEmpty(invite.AllowedUserId) && invite.AllowedUserId != user.Id)
                 {
                     return Result<ChatRoomIdentifierDto>.Failure("This invite is not for you", 403);
+                }
+
+                if (!string.IsNullOrEmpty(invite.AllowedUserId))
+                {
+                    invite.MaxUses = 1;
                 }
 
                 if (invite.MaxUses.HasValue && invite.Uses >= invite.MaxUses.Value)

--- a/Application/Core/MappingProfiles.cs
+++ b/Application/Core/MappingProfiles.cs
@@ -1,5 +1,7 @@
-using Application.ChatRooms.DTOs;
+﻿using Application.ChatRooms.DTOs;
 using Application.DirectChats.DTOs;
+using Application.EncryptedDirectChats.DTOs;
+using Application.EncryptedDirectMessages.DTOs;
 using Application.DirectMessages.DTOs;
 using Application.EmojiPreferences.DTOs;
 using Application.Friends.DTOs;
@@ -151,6 +153,43 @@ public class MappingProfiles : Profile
 
         CreateMap<DirectMessageReaction, MessageReactionDto>()
             .ForMember(d => d.MessageId, o => o.MapFrom(s => s.DirectMessageId))
-            .ForMember(d => d.DisplayName, o => o.MapFrom(s => s.User.DisplayName ?? ""));
+            .ForMember(d => d.DisplayName, o => o.MapFrom(s => s.User.DisplayName ?? string.Empty));
+
+        CreateMap<EncryptedDirectChat, EncryptedDirectChatDto>()
+            .ForMember(d => d.OtherUserId, o => o.MapFrom(s =>
+                s.User1Id == currentUserId ? s.User2Id : s.User1Id))
+            .ForMember(d => d.OtherUserDisplayName, o => o.MapFrom(s =>
+                s.User1Id == currentUserId ? s.User2.DisplayName : s.User1.DisplayName))
+            .ForMember(d => d.OtherUserSlug, o => o.MapFrom(s =>
+                s.User1Id == currentUserId ? s.User2.Slug : s.User1.Slug))
+            .ForMember(d => d.OtherUserImageUrl, o => o.MapFrom(s =>
+                s.User1Id == currentUserId ? s.User2.ImageUrl : s.User1.ImageUrl))
+            .ForMember(d => d.Status, o => o.MapFrom(s =>
+                s.User1Id == currentUserId ? s.User2.Status.ToString() : s.User1.Status.ToString()))
+            .ForMember(d => d.IsOnline, o => o.MapFrom(s =>
+                s.User1Id == currentUserId
+                    ? s.User2.Status.IsConsideredOnline()
+                    : s.User1.Status.IsConsideredOnline()
+            ))
+            .ForMember(d => d.LastSeen, o => o.MapFrom(s =>
+                s.User1Id == currentUserId ? s.User2.LastSeen : s.User1.LastSeen));
+
+        CreateMap<EncryptedDirectMessage, EncryptedDirectMessageDto>()
+            .ForMember(d => d.SenderDisplayName, o => o.MapFrom(s => s.Sender.DisplayName))
+            .ForMember(d => d.SenderSlug, o => o.MapFrom(s => s.Sender.Slug))
+            .ForMember(d => d.SenderImageUrl, o => o.MapFrom(s => s.Sender.ImageUrl))
+            .ForMember(d => d.IsOwnMessage, o => o.MapFrom(s => s.SenderId == currentUserId))
+            .ForMember(d => d.Type, o => o.MapFrom(s => s.Type.ToString()))
+            .ForMember(d => d.ReplyToMessageId, o => o.MapFrom(s => s.ReplyToEncryptedDirectMessageId))
+            .ForMember(d => d.ReplyToCipherText, o => o.MapFrom(s => s.ReplyToEncryptedDirectMessage != null ? s.ReplyToEncryptedDirectMessage.CipherText : null))
+            .ForMember(d => d.ReplyToCipherTextMetadata, o => o.MapFrom(s => s.ReplyToEncryptedDirectMessage != null ? s.ReplyToEncryptedDirectMessage.CipherTextMetadata : null))
+            .ForMember(d => d.ReplyToVersion, o => o.MapFrom(s => s.ReplyToEncryptedDirectMessage != null ? s.ReplyToEncryptedDirectMessage.Version : null))
+            .ForMember(d => d.ReplyToSenderId, o => o.MapFrom(s => s.ReplyToEncryptedDirectMessage != null ? s.ReplyToEncryptedDirectMessage.SenderId : null))
+            .ForMember(d => d.ReplyToSenderDisplayName, o => o.MapFrom(s => s.ReplyToEncryptedDirectMessage != null ? s.ReplyToEncryptedDirectMessage.Sender.DisplayName : null))
+            .ForMember(d => d.Reactions, o => o.MapFrom(s => s.Reactions));
+
+        CreateMap<EncryptedDirectMessageReaction, MessageReactionDto>()
+            .ForMember(d => d.MessageId, o => o.MapFrom(s => s.EncryptedDirectMessageId))
+            .ForMember(d => d.DisplayName, o => o.MapFrom(s => s.User.DisplayName ?? string.Empty));
     }
 }

--- a/Application/EmojiPreferences/Commands/SetEmojiPreference.cs
+++ b/Application/EmojiPreferences/Commands/SetEmojiPreference.cs
@@ -24,11 +24,6 @@ public class SetEmojiPreference
             var user = await userAccessor.GetUserAsync();
             var dto = request.SetEmojiPreferenceDto;
 
-            if (dto.ChatType != "ChatRoom" && dto.ChatType != "DirectChat")
-            {
-                return Result<EmojiPreferenceDto>.Failure("Invalid chat type. Must be 'ChatRoom' or 'DirectChat'", 400);
-            }
-
             if (string.IsNullOrWhiteSpace(dto.DefaultEmoji))
             {
                 return Result<EmojiPreferenceDto>.Failure("Default emoji cannot be empty", 400);
@@ -53,6 +48,17 @@ public class SetEmojiPreference
                 if (!hasAccess)
                 {
                     return Result<EmojiPreferenceDto>.Failure("User does not have access to this direct chat", 403);
+                }
+            }
+            else if (dto.ChatType == "EncryptedDirectChat")
+            {
+                var hasAccess = await context.EncryptedDirectChats
+                    .AnyAsync(edc => edc.Id == dto.ChatId &&
+                                     (edc.User1Id == user.Id || edc.User2Id == user.Id), cancellationToken);
+
+                if (!hasAccess)
+                {
+                    return Result<EmojiPreferenceDto>.Failure("User does not have access to this encrypted direct chat", 403);
                 }
             }
 

--- a/Application/EmojiPreferences/Validators/SetEmojiPreferenceValidator.cs
+++ b/Application/EmojiPreferences/Validators/SetEmojiPreferenceValidator.cs
@@ -7,11 +7,6 @@ public class SetEmojiPreferenceValidator : AbstractValidator<SetEmojiPreference.
 {
     public SetEmojiPreferenceValidator()
     {
-        RuleFor(x => x.SetEmojiPreferenceDto.ChatType)
-            .NotEmpty().WithMessage("Chat type is required")
-            .Must(chatType => chatType == "ChatRoom" || chatType == "DirectChat")
-            .WithMessage("Chat type must be either 'ChatRoom' or 'DirectChat'");
-
         RuleFor(x => x.SetEmojiPreferenceDto.ChatId)
             .NotEmpty().WithMessage("Chat ID is required")
             .Length(1, 50).WithMessage("Chat ID must be between 1 and 50 characters");

--- a/Application/EncryptedDirectChats/Commands/CreateEncryptedDirectChat.cs
+++ b/Application/EncryptedDirectChats/Commands/CreateEncryptedDirectChat.cs
@@ -1,0 +1,74 @@
+﻿using Application.Core;
+using Application.Interfaces;
+using Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace Application.EncryptedDirectChats.Commands;
+
+public class CreateEncryptedDirectChat
+{
+    public class Command : IRequest<Result<string>>
+    {
+        public required string OtherUserId { get; set; }
+    }
+
+    public class Handler(AppDbContext context, IUserAccessor userAccessor)
+        : IRequestHandler<Command, Result<string>>
+    {
+        public async Task<Result<string>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var currentUser = await userAccessor.GetUserAsync();
+
+            if (currentUser.Id == request.OtherUserId)
+            {
+                return Result<string>.Failure("Cannot create encrypted chat with yourself", 400);
+            }
+
+            var areFriends = await context.UserFriends
+                .AnyAsync(uf =>
+                    (uf.UserId == currentUser.Id && uf.FriendId == request.OtherUserId) ||
+                    (uf.UserId == request.OtherUserId && uf.FriendId == currentUser.Id),
+                    cancellationToken);
+
+            if (!areFriends)
+            {
+                return Result<string>.Failure("Can only create encrypted chats with friends", 400);
+            }
+
+            var existingChat = await context.EncryptedDirectChats
+                .FirstOrDefaultAsync(dc =>
+                    (dc.User1Id == currentUser.Id && dc.User2Id == request.OtherUserId) ||
+                    (dc.User1Id == request.OtherUserId && dc.User2Id == currentUser.Id),
+                    cancellationToken);
+
+            if (existingChat is not null)
+            {
+                return Result<string>.Success(existingChat.Id);
+            }
+
+            var ordered = string.CompareOrdinal(currentUser.Id, request.OtherUserId) <= 0
+                ? (User1Id: currentUser.Id, User2Id: request.OtherUserId)
+                : (User1Id: request.OtherUserId, User2Id: currentUser.Id);
+
+            var encryptedChat = new EncryptedDirectChat
+            {
+                User1Id = ordered.User1Id,
+                User2Id = ordered.User2Id,
+                LastMessageSenderId = null,
+                LastActivityAt = DateTime.UtcNow,
+            };
+
+            context.EncryptedDirectChats.Add(encryptedChat);
+
+            var result = await context.SaveChangesAsync(cancellationToken) > 0;
+            if (!result)
+            {
+                return Result<string>.Failure("Failed to create encrypted chat", 400);
+            }
+
+            return Result<string>.Success(encryptedChat.Id);
+        }
+    }
+}

--- a/Application/EncryptedDirectChats/DTOs/EncryptedDirectChatDto.cs
+++ b/Application/EncryptedDirectChats/DTOs/EncryptedDirectChatDto.cs
@@ -1,0 +1,15 @@
+﻿namespace Application.EncryptedDirectChats.DTOs;
+
+public class EncryptedDirectChatDto
+{
+    public required string Id { get; set; }
+    public required string OtherUserId { get; set; }
+    public required string OtherUserDisplayName { get; set; }
+    public required string OtherUserSlug { get; set; }
+    public string? OtherUserImageUrl { get; set; }
+    public DateTime LastActivityAt { get; set; }
+    public string? LastMessageSenderId { get; set; }
+    public bool IsOnline { get; set; }
+    public DateTime? LastSeen { get; set; }
+    public string Status { get; set; } = "Offline";
+}

--- a/Application/EncryptedDirectChats/Queries/GetEncryptedDirectChats.cs
+++ b/Application/EncryptedDirectChats/Queries/GetEncryptedDirectChats.cs
@@ -1,0 +1,55 @@
+﻿using Application.Core;
+using Application.EncryptedDirectChats.DTOs;
+using Application.Interfaces;
+using Domain.Extensions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace Application.EncryptedDirectChats.Queries;
+
+public class GetEncryptedDirectChats
+{
+    public class Query : IRequest<Result<List<EncryptedDirectChatDto>>> { }
+
+    public class Handler(AppDbContext context, IUserAccessor userAccessor)
+        : IRequestHandler<Query, Result<List<EncryptedDirectChatDto>>>
+    {
+        public async Task<Result<List<EncryptedDirectChatDto>>> Handle(Query request, CancellationToken cancellationToken)
+        {
+            var currentUser = await userAccessor.GetUserAsync();
+
+            var chats = await context.EncryptedDirectChats
+                .Where(dc => dc.User1Id == currentUser.Id || dc.User2Id == currentUser.Id)
+                .Include(dc => dc.User1)
+                .Include(dc => dc.User2)
+                .OrderByDescending(dc => dc.LastActivityAt)
+                .Select(dc => new EncryptedDirectChatDto
+                {
+                    Id = dc.Id,
+                    OtherUserId = dc.User1Id == currentUser.Id ? dc.User2Id : dc.User1Id,
+                    OtherUserDisplayName = dc.User1Id == currentUser.Id
+                        ? dc.User2.DisplayName ?? string.Empty
+                        : dc.User1.DisplayName ?? string.Empty,
+                    OtherUserSlug = dc.User1Id == currentUser.Id
+                        ? dc.User2.Slug
+                        : dc.User1.Slug,
+                    OtherUserImageUrl = dc.User1Id == currentUser.Id
+                        ? dc.User2.ImageUrl
+                        : dc.User1.ImageUrl,
+                    LastActivityAt = dc.LastActivityAt,
+                    LastMessageSenderId = dc.LastMessageSenderId,
+                    IsOnline = dc.User1Id == currentUser.Id
+                        ? dc.User2.Status.IsConsideredOnline()
+                        : dc.User1.Status.IsConsideredOnline(),
+                    LastSeen = dc.User1Id == currentUser.Id ? dc.User2.LastSeen : dc.User1.LastSeen,
+                    Status = dc.User1Id == currentUser.Id
+                        ? dc.User2.Status.ToString()
+                        : dc.User1.Status.ToString()
+                })
+                .ToListAsync(cancellationToken);
+
+            return Result<List<EncryptedDirectChatDto>>.Success(chats);
+        }
+    }
+}

--- a/Application/EncryptedDirectMessages/Commands/SendEncryptedDirectMessage.cs
+++ b/Application/EncryptedDirectMessages/Commands/SendEncryptedDirectMessage.cs
@@ -1,0 +1,106 @@
+﻿using Application.Core;
+using Application.EncryptedDirectMessages.DTOs;
+using Application.Interfaces;
+using AutoMapper;
+using Domain;
+using Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace Application.EncryptedDirectMessages.Commands;
+
+public class SendEncryptedDirectMessage
+{
+    public class Command : IRequest<Result<EncryptedDirectMessageDto>>
+    {
+        public required string EncryptedDirectChatId { get; set; }
+        public required string CipherText { get; set; }
+        public string? CipherTextMetadata { get; set; }
+        public string Version { get; set; } = "v1";
+        public string Type { get; set; } = "Text";
+        public string? ReplyToMessageId { get; set; }
+    }
+
+    public class Handler(AppDbContext context, IMapper mapper, IUserAccessor userAccessor)
+        : IRequestHandler<Command, Result<EncryptedDirectMessageDto>>
+    {
+        public async Task<Result<EncryptedDirectMessageDto>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(request.CipherText))
+            {
+                return Result<EncryptedDirectMessageDto>.Failure("Cipher text is required", 422);
+            }
+
+            var currentUser = await userAccessor.GetUserAsync();
+
+            var chat = await context.EncryptedDirectChats
+                .Include(dc => dc.Messages)
+                .FirstOrDefaultAsync(dc => dc.Id == request.EncryptedDirectChatId, cancellationToken);
+
+            if (chat is null)
+            {
+                return Result<EncryptedDirectMessageDto>.Failure("Encrypted chat not found", 404);
+            }
+
+            if (chat.User1Id != currentUser.Id && chat.User2Id != currentUser.Id)
+            {
+                return Result<EncryptedDirectMessageDto>.Failure("Access denied", 403);
+            }
+
+            var otherUserId = chat.User1Id == currentUser.Id ? chat.User2Id : chat.User1Id;
+            var areFriends = await context.UserFriends
+                .AnyAsync(uf =>
+                    (uf.UserId == currentUser.Id && uf.FriendId == otherUserId) ||
+                    (uf.UserId == otherUserId && uf.FriendId == currentUser.Id),
+                    cancellationToken);
+
+            if (!areFriends)
+            {
+                return Result<EncryptedDirectMessageDto>.Failure("You can only send encrypted messages to friends", 403);
+            }
+
+            if (!Enum.TryParse<MessageType>(request.Type, out var messageType))
+            {
+                messageType = MessageType.Text;
+            }
+
+            var message = new EncryptedDirectMessage
+            {
+                SenderId = currentUser.Id,
+                EncryptedDirectChatId = chat.Id,
+                CipherText = request.CipherText,
+                CipherTextMetadata = request.CipherTextMetadata,
+                Version = string.IsNullOrWhiteSpace(request.Version) ? "v1" : request.Version,
+                Type = messageType,
+            };
+
+            if (!string.IsNullOrEmpty(request.ReplyToMessageId))
+            {
+                var repliedTo = await context.EncryptedDirectMessages
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(m => m.Id == request.ReplyToMessageId, cancellationToken);
+                if (repliedTo is null || repliedTo.EncryptedDirectChatId != chat.Id)
+                {
+                    return Result<EncryptedDirectMessageDto>.Failure("Invalid replied message", 400);
+                }
+                message.ReplyToEncryptedDirectMessageId = repliedTo.Id;
+            }
+
+            chat.Messages.Add(message);
+            chat.LastActivityAt = message.CreatedAt;
+            chat.LastMessageSenderId = message.SenderId;
+
+            var saved = await context.SaveChangesAsync(cancellationToken) > 0;
+            if (!saved)
+            {
+                return Result<EncryptedDirectMessageDto>.Failure("Failed to send encrypted message", 400);
+            }
+
+            var dto = mapper.Map<EncryptedDirectMessageDto>(message);
+            dto.IsOwnMessage = true;
+
+            return Result<EncryptedDirectMessageDto>.Success(dto);
+        }
+    }
+}

--- a/Application/EncryptedDirectMessages/Commands/ToggleEncryptedDirectMessageReaction.cs
+++ b/Application/EncryptedDirectMessages/Commands/ToggleEncryptedDirectMessageReaction.cs
@@ -1,0 +1,123 @@
+﻿using Application.Core;
+using Application.Interfaces;
+using Application.Messages.DTOs;
+using Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace Application.EncryptedDirectMessages.Commands;
+
+public class ToggleEncryptedDirectMessageReaction
+{
+    public class Command : IRequest<Result<ReactionUpdateDto>>
+    {
+        public required string EncryptedDirectChatId { get; set; }
+        public required string EncryptedDirectMessageId { get; set; }
+        public required string Emoji { get; set; }
+    }
+
+    public class Handler(AppDbContext context, IUserAccessor userAccessor)
+        : IRequestHandler<Command, Result<ReactionUpdateDto>>
+    {
+        private static string BuildEmojiKey(string emoji)
+        {
+            if (string.IsNullOrEmpty(emoji)) return string.Empty;
+            var cps = new List<int>();
+            for (int i = 0; i < emoji.Length; i++)
+            {
+                int code = char.ConvertToUtf32(emoji, i);
+                if (char.IsHighSurrogate(emoji[i])) i++;
+                if (code == 0xFE0F) continue;
+                cps.Add(code);
+            }
+            return string.Join("-", cps.Select(c => c.ToString("X")));
+        }
+
+        public async Task<Result<ReactionUpdateDto>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var user = await userAccessor.GetUserAsync();
+
+            var chat = await context.EncryptedDirectChats.AsNoTracking()
+                .FirstOrDefaultAsync(dc => dc.Id == request.EncryptedDirectChatId, cancellationToken);
+            if (chat is null)
+            {
+                return Result<ReactionUpdateDto>.Failure("Chat not found", 404);
+            }
+
+            if (chat.User1Id != user.Id && chat.User2Id != user.Id)
+            {
+                return Result<ReactionUpdateDto>.Failure("Access denied", 403);
+            }
+
+            var message = await context.EncryptedDirectMessages
+                .Include(m => m.Sender)
+                .FirstOrDefaultAsync(m =>
+                    m.Id == request.EncryptedDirectMessageId &&
+                    m.EncryptedDirectChatId == request.EncryptedDirectChatId,
+                    cancellationToken);
+
+            if (message is null)
+            {
+                return Result<ReactionUpdateDto>.Failure("Message not found", 404);
+            }
+
+            var normalizedEmoji = request.Emoji.Trim();
+            if (string.IsNullOrEmpty(normalizedEmoji))
+            {
+                return Result<ReactionUpdateDto>.Failure("Invalid emoji", 400);
+            }
+
+            var emojiKey = BuildEmojiKey(normalizedEmoji);
+            if (string.IsNullOrEmpty(emojiKey))
+            {
+                return Result<ReactionUpdateDto>.Failure("Invalid emoji", 400);
+            }
+
+            var existing = await context.EncryptedDirectMessageReactions.FirstOrDefaultAsync(r =>
+                r.EncryptedDirectMessageId == request.EncryptedDirectMessageId &&
+                r.UserId == user.Id &&
+                (r.EmojiKey == emojiKey || (r.EmojiKey == string.Empty && r.Emoji == normalizedEmoji)),
+                cancellationToken);
+
+            if (existing is not null)
+            {
+                if (string.IsNullOrEmpty(existing.EmojiKey)) existing.EmojiKey = emojiKey;
+                context.EncryptedDirectMessageReactions.Remove(existing);
+                await context.SaveChangesAsync(cancellationToken);
+
+                return Result<ReactionUpdateDto>.Success(new ReactionUpdateDto
+                {
+                    Action = "removed",
+                    ChatRoomId = request.EncryptedDirectChatId,
+                    MessageId = request.EncryptedDirectMessageId,
+                    Emoji = normalizedEmoji,
+                    UserId = user.Id,
+                    DisplayName = user.DisplayName ?? "Unknown",
+                    CreatedAt = existing.CreatedAt
+                });
+            }
+
+            var reaction = new EncryptedDirectMessageReaction
+            {
+                EncryptedDirectMessageId = request.EncryptedDirectMessageId,
+                UserId = user.Id,
+                Emoji = normalizedEmoji,
+                EmojiKey = emojiKey
+            };
+            context.EncryptedDirectMessageReactions.Add(reaction);
+            await context.SaveChangesAsync(cancellationToken);
+
+            return Result<ReactionUpdateDto>.Success(new ReactionUpdateDto
+            {
+                Action = "added",
+                ChatRoomId = request.EncryptedDirectChatId,
+                MessageId = request.EncryptedDirectMessageId,
+                Emoji = normalizedEmoji,
+                UserId = user.Id,
+                DisplayName = user.DisplayName ?? "Unknown",
+                CreatedAt = reaction.CreatedAt
+            });
+        }
+    }
+}

--- a/Application/EncryptedDirectMessages/DTOs/EncryptedDirectMessageDto.cs
+++ b/Application/EncryptedDirectMessages/DTOs/EncryptedDirectMessageDto.cs
@@ -1,0 +1,25 @@
+﻿namespace Application.EncryptedDirectMessages.DTOs;
+
+public class EncryptedDirectMessageDto
+{
+    public required string Id { get; set; }
+    public required string CipherText { get; set; }
+    public string? CipherTextMetadata { get; set; }
+    public string Version { get; set; } = "v1";
+    public DateTime CreatedAt { get; set; }
+    public required string SenderId { get; set; }
+    public required string SenderDisplayName { get; set; }
+    public required string SenderSlug { get; set; }
+    public string? SenderImageUrl { get; set; }
+    public bool IsOwnMessage { get; set; }
+    public string Type { get; set; } = "Text";
+
+    public string? ReplyToMessageId { get; set; }
+    public string? ReplyToCipherText { get; set; }
+    public string? ReplyToCipherTextMetadata { get; set; }
+    public string? ReplyToVersion { get; set; }
+    public string? ReplyToSenderId { get; set; }
+    public string? ReplyToSenderDisplayName { get; set; }
+
+    public List<Application.Messages.DTOs.MessageReactionDto> Reactions { get; set; } = [];
+}

--- a/Application/EncryptedDirectMessages/Queries/GetEncryptedDirectMessages.cs
+++ b/Application/EncryptedDirectMessages/Queries/GetEncryptedDirectMessages.cs
@@ -1,0 +1,124 @@
+﻿using Application.Core;
+using Application.EncryptedDirectMessages.DTOs;
+using Application.Interfaces;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace Application.EncryptedDirectMessages.Queries;
+
+public class GetEncryptedDirectMessages
+{
+    public class Query : IRequest<Result<PagedList<EncryptedDirectMessageDto, DateTime?>>>
+    {
+        public required string EncryptedDirectChatId { get; set; }
+        public DateTime? Cursor { get; set; }
+        public int PageSize { get; set; } = 20;
+    }
+
+    public class Handler(AppDbContext context, IMapper mapper, IUserAccessor userAccessor)
+        : IRequestHandler<Query, Result<PagedList<EncryptedDirectMessageDto, DateTime?>>>
+    {
+        public async Task<Result<PagedList<EncryptedDirectMessageDto, DateTime?>>> Handle(
+            Query request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = await userAccessor.GetUserAsync();
+
+            var hasAccess = await context.EncryptedDirectChats
+                .AnyAsync(dc => dc.Id == request.EncryptedDirectChatId &&
+                                (dc.User1Id == currentUser.Id || dc.User2Id == currentUser.Id),
+                         cancellationToken);
+
+            if (!hasAccess)
+            {
+                return Result<PagedList<EncryptedDirectMessageDto, DateTime?>>.Failure("Access denied", 403);
+            }
+
+            if (!request.Cursor.HasValue)
+            {
+                var totalMessages = await context.EncryptedDirectMessages
+                    .Where(x => x.EncryptedDirectChatId == request.EncryptedDirectChatId)
+                    .CountAsync(cancellationToken);
+
+                var query = context.EncryptedDirectMessages
+                    .Where(x => x.EncryptedDirectChatId == request.EncryptedDirectChatId)
+                    .Include(x => x.Reactions).ThenInclude(r => r.User)
+                    .Include(x => x.ReplyToEncryptedDirectMessage).ThenInclude(m => m!.Sender)
+                    .OrderBy(x => x.CreatedAt);
+
+                var messages = new List<EncryptedDirectMessageDto>();
+                DateTime? nextCursor = null;
+
+                if (totalMessages > request.PageSize)
+                {
+                    var skip = totalMessages - request.PageSize;
+                    messages = await query
+                        .Skip(skip)
+                        .Take(request.PageSize)
+                        .ProjectTo<EncryptedDirectMessageDto>(
+                            mapper.ConfigurationProvider,
+                            new { currentUserId = currentUser.Id }
+                        )
+                        .ToListAsync(cancellationToken);
+
+                    if (messages.Count != 0)
+                    {
+                        nextCursor = messages[0].CreatedAt;
+                    }
+                }
+                else
+                {
+                    messages = await query
+                        .Take(request.PageSize)
+                        .ProjectTo<EncryptedDirectMessageDto>(
+                            mapper.ConfigurationProvider,
+                            new { currentUserId = currentUser.Id }
+                        )
+                        .ToListAsync(cancellationToken);
+                }
+
+                return Result<PagedList<EncryptedDirectMessageDto, DateTime?>>.Success(
+                    new PagedList<EncryptedDirectMessageDto, DateTime?>
+                    {
+                        Items = messages,
+                        NextCursor = nextCursor
+                    }
+                );
+            }
+            else
+            {
+                var messages = await context.EncryptedDirectMessages
+                    .Where(x => x.EncryptedDirectChatId == request.EncryptedDirectChatId && x.CreatedAt < request.Cursor.Value)
+                    .Include(x => x.Reactions).ThenInclude(r => r.User)
+                    .Include(x => x.ReplyToEncryptedDirectMessage).ThenInclude(m => m!.Sender)
+                    .OrderByDescending(x => x.CreatedAt)
+                    .Take(request.PageSize + 1)
+                    .ProjectTo<EncryptedDirectMessageDto>(
+                        mapper.ConfigurationProvider,
+                        new { currentUserId = currentUser.Id }
+                    )
+                    .ToListAsync(cancellationToken);
+
+                messages.Reverse();
+
+                DateTime? nextCursor = null;
+                if (messages.Count > request.PageSize)
+                {
+                    nextCursor = messages[0].CreatedAt;
+                    messages.RemoveAt(0);
+                }
+
+                return Result<PagedList<EncryptedDirectMessageDto, DateTime?>>.Success(
+                    new PagedList<EncryptedDirectMessageDto, DateTime?>
+                    {
+                        Items = messages,
+                        NextCursor = nextCursor
+                    }
+                );
+            }
+        }
+    }
+}

--- a/Application/Friends/EventHandlers/CreateDirectChatOnFriendshipHandler.cs
+++ b/Application/Friends/EventHandlers/CreateDirectChatOnFriendshipHandler.cs
@@ -1,4 +1,5 @@
-using Application.DirectChats.Commands;
+﻿using Application.DirectChats.Commands;
+using Application.EncryptedDirectChats.Commands;
 using Application.Friends.Events;
 using Application.Interfaces;
 using MediatR;
@@ -13,5 +14,6 @@ public class CreateDirectChatOnFriendshipHandler(IMediator mediator, IUserAccess
         var otherUserId = currentUser.Id == notification.User1Id ? notification.User2Id : notification.User1Id;
 
         await mediator.Send(new CreateDirectChat.Command { OtherUserId = otherUserId }, cancellationToken);
+        await mediator.Send(new CreateEncryptedDirectChat.Command { OtherUserId = otherUserId }, cancellationToken);
     }
 }

--- a/Application/Interfaces/IEncryptedDirectMessagesNotificationService.cs
+++ b/Application/Interfaces/IEncryptedDirectMessagesNotificationService.cs
@@ -1,0 +1,8 @@
+﻿using Application.EncryptedDirectMessages.DTOs;
+
+namespace Application.Interfaces;
+
+public interface IEncryptedDirectMessagesNotificationService
+{
+    Task NotifyNewMessage(string encryptedDirectChatId, EncryptedDirectMessageDto message, bool broadcastToEncryptedChat = false);
+}

--- a/Application/Notifications/Commands/MarkEncryptedDirectChatNotificationsRead.cs
+++ b/Application/Notifications/Commands/MarkEncryptedDirectChatNotificationsRead.cs
@@ -1,0 +1,48 @@
+﻿using Application.Core;
+using Application.Interfaces;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistance;
+
+namespace Application.Notifications.Commands;
+
+public class MarkEncryptedDirectChatNotificationsRead
+{
+    public class Command : IRequest<Result<Unit>>
+    {
+        public required string EncryptedDirectChatId { get; set; }
+    }
+
+    public class Handler(AppDbContext context, IUserAccessor userAccessor)
+        : IRequestHandler<Command, Result<Unit>>
+    {
+        public async Task<Result<Unit>> Handle(Command request, CancellationToken cancellationToken)
+        {
+            var user = await userAccessor.GetUserAsync();
+
+            var notification = await context.EncryptedDirectChatNotifications
+                .FirstOrDefaultAsync(
+                    n => n.UserId == user.Id && n.EncryptedDirectChatId == request.EncryptedDirectChatId,
+                    cancellationToken
+                );
+
+            if (notification is null)
+            {
+                return Result<Unit>.Success(Unit.Value);
+            }
+
+            if (notification.UnreadCount == 0)
+            {
+                return Result<Unit>.Success(Unit.Value);
+            }
+
+            notification.UnreadCount = 0;
+            notification.UpdatedAt = DateTime.UtcNow;
+
+            var success = await context.SaveChangesAsync(cancellationToken) > 0;
+            return success
+                ? Result<Unit>.Success(Unit.Value)
+                : Result<Unit>.Failure("Failed to update notifications", 500);
+        }
+    }
+}

--- a/Application/Notifications/DTOs/NotificationCountersDto.cs
+++ b/Application/Notifications/DTOs/NotificationCountersDto.cs
@@ -1,7 +1,8 @@
-namespace Application.Notifications.DTOs;
+﻿namespace Application.Notifications.DTOs;
 
 public class NotificationCountersDto
 {
     public Dictionary<string, int> ChatRooms { get; set; } = [];
     public Dictionary<string, int> DirectChats { get; set; } = [];
+    public Dictionary<string, int> EncryptedDirectChats { get; set; } = [];
 }

--- a/Application/Notifications/Queries/GetNotificationCounters.cs
+++ b/Application/Notifications/Queries/GetNotificationCounters.cs
@@ -1,4 +1,4 @@
-using Application.Core;
+﻿using Application.Core;
 using Application.Interfaces;
 using Application.Notifications.DTOs;
 using MediatR;
@@ -28,10 +28,16 @@ public class GetNotificationCounters
                 .Select(n => new { n.DirectChatId, n.UnreadCount })
                 .ToListAsync(cancellationToken);
 
+            var encryptedDirectChatCounters = await context.EncryptedDirectChatNotifications
+                .Where(n => n.UserId == user.Id && n.UnreadCount > 0)
+                .Select(n => new { n.EncryptedDirectChatId, n.UnreadCount })
+                .ToListAsync(cancellationToken);
+
             var dto = new NotificationCountersDto
             {
                 ChatRooms = chatRoomCounters.ToDictionary(x => x.ChatRoomId, x => x.UnreadCount),
                 DirectChats = directChatCounters.ToDictionary(x => x.DirectChatId, x => x.UnreadCount),
+                EncryptedDirectChats = encryptedDirectChatCounters.ToDictionary(x => x.EncryptedDirectChatId, x => x.UnreadCount),
             };
 
             return Result<NotificationCountersDto>.Success(dto);

--- a/Domain/EncryptedDirectChat.cs
+++ b/Domain/EncryptedDirectChat.cs
@@ -1,0 +1,15 @@
+﻿namespace Domain;
+
+public class EncryptedDirectChat
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public required string User1Id { get; set; }
+    public User User1 { get; set; } = null!;
+    public required string User2Id { get; set; }
+    public User User2 { get; set; } = null!;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime LastActivityAt { get; set; } = DateTime.UtcNow;
+    public string? LastMessageSenderId { get; set; }
+
+    public ICollection<EncryptedDirectMessage> Messages { get; set; } = [];
+}

--- a/Domain/EncryptedDirectChatNotification.cs
+++ b/Domain/EncryptedDirectChatNotification.cs
@@ -1,0 +1,10 @@
+﻿namespace Domain;
+
+public class EncryptedDirectChatNotification
+{
+    public Guid Id { get; set; }
+    public required string UserId { get; set; }
+    public required string EncryptedDirectChatId { get; set; }
+    public int UnreadCount { get; set; }
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Domain/EncryptedDirectMessage.cs
+++ b/Domain/EncryptedDirectMessage.cs
@@ -1,0 +1,23 @@
+﻿using Domain.Enums;
+
+namespace Domain;
+
+public class EncryptedDirectMessage
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public required string CipherText { get; set; }
+    public string? CipherTextMetadata { get; set; }
+    public string Version { get; set; } = "v1";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public MessageType Type { get; set; } = MessageType.Text;
+
+    public required string SenderId { get; set; }
+    public User Sender { get; set; } = null!;
+    public required string EncryptedDirectChatId { get; set; }
+    public EncryptedDirectChat EncryptedDirectChat { get; set; } = null!;
+
+    public string? ReplyToEncryptedDirectMessageId { get; set; }
+    public EncryptedDirectMessage? ReplyToEncryptedDirectMessage { get; set; }
+
+    public ICollection<EncryptedDirectMessageReaction> Reactions { get; set; } = [];
+}

--- a/Domain/EncryptedDirectMessageReaction.cs
+++ b/Domain/EncryptedDirectMessageReaction.cs
@@ -1,0 +1,16 @@
+﻿namespace Domain;
+
+public class EncryptedDirectMessageReaction
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    public required string EncryptedDirectMessageId { get; set; }
+    public EncryptedDirectMessage EncryptedDirectMessage { get; set; } = null!;
+
+    public required string UserId { get; set; }
+    public User User { get; set; } = null!;
+
+    public required string Emoji { get; set; }
+    public required string EmojiKey { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Persistance/AppDbContext.cs
+++ b/Persistance/AppDbContext.cs
@@ -1,4 +1,4 @@
-using Domain;
+﻿using Domain;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
@@ -26,6 +26,11 @@ public class AppDbContext(DbContextOptions options) : IdentityDbContext<User>(op
     public required DbSet<ChatRoomInvite> ChatRoomInvites { get; set; }
     public required DbSet<ChatRoomNotification> ChatRoomNotifications { get; set; }
     public required DbSet<DirectChatNotification> DirectChatNotifications { get; set; }
+    public required DbSet<EncryptedDirectChat> EncryptedDirectChats { get; set; }
+    public required DbSet<EncryptedDirectMessage> EncryptedDirectMessages { get; set; }
+    public required DbSet<EncryptedDirectMessageReaction> EncryptedDirectMessageReactions { get; set; }
+    public required DbSet<EncryptedDirectChatNotification> EncryptedDirectChatNotifications { get; set; }
+
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -221,7 +226,94 @@ public class AppDbContext(DbContextOptions options) : IdentityDbContext<User>(op
             x.HasIndex(r => new { r.DirectMessageId, r.CreatedAt });
         });
 
-        // Reply relationship for chat room messages
+        builder.Entity<EncryptedDirectChat>(x =>
+        {
+            x.HasKey(dc => dc.Id);
+
+            x.HasOne(dc => dc.User1)
+                .WithMany()
+                .HasForeignKey(dc => dc.User1Id)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            x.HasOne(dc => dc.User2)
+                .WithMany()
+                .HasForeignKey(dc => dc.User2Id)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            x.HasIndex(dc => new { dc.User1Id, dc.User2Id })
+                .IsUnique();
+
+            x.Property(dc => dc.LastActivityAt).IsRequired();
+        });
+
+        builder.Entity<EncryptedDirectMessage>(x =>
+        {
+            x.HasKey(dm => dm.Id);
+
+            x.Property(dm => dm.CipherText)
+                .IsRequired();
+
+            x.Property(dm => dm.Version)
+                .HasMaxLength(10);
+
+            x.HasOne(dm => dm.Sender)
+                .WithMany()
+                .HasForeignKey(dm => dm.SenderId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            x.HasOne(dm => dm.EncryptedDirectChat)
+                .WithMany(dc => dc.Messages)
+                .HasForeignKey(dm => dm.EncryptedDirectChatId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            x.HasOne(dm => dm.ReplyToEncryptedDirectMessage)
+                .WithMany()
+                .HasForeignKey(dm => dm.ReplyToEncryptedDirectMessageId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            x.HasIndex(dm => new { dm.EncryptedDirectChatId, dm.CreatedAt });
+        });
+
+        builder.Entity<EncryptedDirectMessageReaction>(x =>
+        {
+            x.HasKey(r => r.Id);
+
+            x.Property(r => r.Emoji).IsRequired().HasMaxLength(64);
+            x.Property(r => r.EmojiKey).IsRequired().HasMaxLength(128);
+
+            x.HasOne(r => r.EncryptedDirectMessage)
+                .WithMany(m => m.Reactions)
+                .HasForeignKey(r => r.EncryptedDirectMessageId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            x.HasOne(r => r.User)
+                .WithMany()
+                .HasForeignKey(r => r.UserId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            x.HasIndex(r => new { r.EncryptedDirectMessageId, r.UserId, r.EmojiKey }).IsUnique();
+        });
+
+        builder.Entity<EncryptedDirectChatNotification>(entity =>
+        {
+            entity.HasKey(n => n.Id);
+            entity.Property(n => n.UserId).IsRequired();
+            entity.Property(n => n.EncryptedDirectChatId).IsRequired();
+            entity.Property(n => n.UnreadCount).IsRequired();
+            entity.Property(n => n.UpdatedAt).IsRequired();
+
+            entity.HasIndex(n => new { n.UserId, n.EncryptedDirectChatId }).IsUnique();
+
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(n => n.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne<EncryptedDirectChat>()
+                .WithMany()
+                .HasForeignKey(n => n.EncryptedDirectChatId)
+                .OnDelete(DeleteBehavior.NoAction);
+        });
         builder.Entity<Message>(x =>
         {
             // Encrypt message body at rest
@@ -404,4 +496,11 @@ public class AppDbContext(DbContextOptions options) : IdentityDbContext<User>(op
         }
     }
 }
+
+
+
+
+
+
+
 

--- a/Persistance/Migrations/20250922092156_AddE2EEDataModels.Designer.cs
+++ b/Persistance/Migrations/20250922092156_AddE2EEDataModels.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Persistance;
 
@@ -11,9 +12,11 @@ using Persistance;
 namespace Persistance.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250922092156_AddE2EEDataModels")]
+    partial class AddE2EEDataModels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistance/Migrations/20250922092156_AddE2EEDataModels.cs
+++ b/Persistance/Migrations/20250922092156_AddE2EEDataModels.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistance.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddE2EEDataModels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EncryptedDirectChats",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    User1Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    User2Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    LastActivityAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    LastMessageSenderId = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EncryptedDirectChats", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectChats_AspNetUsers_User1Id",
+                        column: x => x.User1Id,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectChats_AspNetUsers_User2Id",
+                        column: x => x.User2Id,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EncryptedDirectChatNotifications",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EncryptedDirectChatId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UnreadCount = table.Column<int>(type: "int", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EncryptedDirectChatNotifications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectChatNotifications_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectChatNotifications_EncryptedDirectChats_EncryptedDirectChatId",
+                        column: x => x.EncryptedDirectChatId,
+                        principalTable: "EncryptedDirectChats",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EncryptedDirectMessages",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CipherText = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CipherTextMetadata = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Version = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    SenderId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EncryptedDirectChatId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ReplyToEncryptedDirectMessageId = table.Column<string>(type: "nvarchar(450)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EncryptedDirectMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectMessages_AspNetUsers_SenderId",
+                        column: x => x.SenderId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectMessages_EncryptedDirectChats_EncryptedDirectChatId",
+                        column: x => x.EncryptedDirectChatId,
+                        principalTable: "EncryptedDirectChats",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectMessages_EncryptedDirectMessages_ReplyToEncryptedDirectMessageId",
+                        column: x => x.ReplyToEncryptedDirectMessageId,
+                        principalTable: "EncryptedDirectMessages",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EncryptedDirectMessageReactions",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    EncryptedDirectMessageId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Emoji = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    EmojiKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EncryptedDirectMessageReactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectMessageReactions_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_EncryptedDirectMessageReactions_EncryptedDirectMessages_EncryptedDirectMessageId",
+                        column: x => x.EncryptedDirectMessageId,
+                        principalTable: "EncryptedDirectMessages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectChatNotifications_EncryptedDirectChatId",
+                table: "EncryptedDirectChatNotifications",
+                column: "EncryptedDirectChatId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectChatNotifications_UserId_EncryptedDirectChatId",
+                table: "EncryptedDirectChatNotifications",
+                columns: new[] { "UserId", "EncryptedDirectChatId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectChats_User1Id_User2Id",
+                table: "EncryptedDirectChats",
+                columns: new[] { "User1Id", "User2Id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectChats_User2Id",
+                table: "EncryptedDirectChats",
+                column: "User2Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectMessageReactions_EncryptedDirectMessageId_UserId_EmojiKey",
+                table: "EncryptedDirectMessageReactions",
+                columns: new[] { "EncryptedDirectMessageId", "UserId", "EmojiKey" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectMessageReactions_UserId",
+                table: "EncryptedDirectMessageReactions",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectMessages_EncryptedDirectChatId_CreatedAt",
+                table: "EncryptedDirectMessages",
+                columns: new[] { "EncryptedDirectChatId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectMessages_ReplyToEncryptedDirectMessageId",
+                table: "EncryptedDirectMessages",
+                column: "ReplyToEncryptedDirectMessageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncryptedDirectMessages_SenderId",
+                table: "EncryptedDirectMessages",
+                column: "SenderId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EncryptedDirectChatNotifications");
+
+            migrationBuilder.DropTable(
+                name: "EncryptedDirectMessageReactions");
+
+            migrationBuilder.DropTable(
+                name: "EncryptedDirectMessages");
+
+            migrationBuilder.DropTable(
+                name: "EncryptedDirectChats");
+        }
+    }
+}

--- a/client/.env.development
+++ b/client/.env.development
@@ -5,6 +5,8 @@ VITE_DIRECT_MESSAGE_URL=https://localhost:5001/direct-messages
 VITE_STATUS_URL=https://localhost:5001/status
 VITE_CHATROOM_ROLES_URL=https://localhost:5001/chatroom-roles
 VITE_CHATROOM_IMAGES_URL=https://localhost:5001/chatroom-image-update
+VITE_CHATROOM_ENCRYPTED_DIRECT_MESSAGES_URL=https://localhost:5001/encrypted-direct-messages
+VITE_CHATROOM_ENCRYPTED_MESSAGES_URL=https://localhost:5001/encrypted-messages
 
 VITE_REDIRECT_URL=https://localhost:3000/auth-callback
 VITE_GITHUB_CLIENT_ID=Ov23lig2V1dgySURnP8X

--- a/client/.env.production
+++ b/client/.env.production
@@ -5,6 +5,8 @@ VITE_DIRECT_MESSAGE_URL=https://ratchat.pl/direct-messages
 VITE_STATUS_URL=https://ratchat.pl/status
 VITE_CHATROOM_ROLES_URL=https://ratchat.pl/chatroom-roles
 VITE_CHATROOM_IMAGES_URL=https://ratchat.pl/chatroom-image-update
+VITE_CHATROOM_ENCRYPTED_DIRECT_MESSAGES_URL=https://ratchat.pl/encrypted-direct-messages
+VITE_CHATROOM_ENCRYPTED_MESSAGES_URL=https://ratchat.pl/encrypted-messages
 
 VITE_REDIRECT_URL=https://ratchat.pl/auth-callback
 VITE_GITHUB_CLIENT_ID=Ov23liSH0DPSi6vyQbMe

--- a/client/src/app/layout/SideNav/DefaultSidebarContent.tsx
+++ b/client/src/app/layout/SideNav/DefaultSidebarContent.tsx
@@ -1,4 +1,4 @@
-﻿import { PeopleAlt } from "@mui/icons-material";
+import { PeopleAlt } from "@mui/icons-material";
 import {
   Badge,
   Box,
@@ -36,6 +36,9 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
   const { directChats } = useDirectChats();
   const { encryptedDirectChats } = useEncryptedDirectChats();
   const { messagesNotificationsStore } = useStore();
+  const directUnreadCount = messagesNotificationsStore.totalDirectUnread;
+  const encryptedUnreadCount =
+    messagesNotificationsStore.totalEncryptedDirectUnread;
 
   const handleChatViewChange = (
     _: React.MouseEvent<HTMLElement>,
@@ -142,12 +145,10 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
 
       <Box
         sx={{
-          px: 2,
+          px: 1,
           py: 1,
           display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
-          gap: 1,
         }}
       >
         <ToggleButtonGroup
@@ -158,13 +159,89 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
           sx={{
             backgroundColor: "rgba(255,255,255,0.04)",
             flex: 1,
+            overflow: "hidden",
           }}
         >
-          <ToggleButton value="direct" sx={{ color: "white", flex: 1 }}>
-            Direct
+          <ToggleButton
+            value="direct"
+            sx={{ color: "white", flex: 1, minWidth: 0, p: 0 }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                width: "100%",
+                minWidth: 0,
+                px: 1.5,
+              }}
+            >
+              <Typography
+                noWrap
+                sx={{
+                  textOverflow: "ellipsis",
+                  overflow: "hidden",
+                  minWidth: 0,
+                  flex: 1,
+                }}
+              >
+                Direct
+              </Typography>
+              <Badge
+                color="error"
+                badgeContent={directUnreadCount}
+                invisible={!directUnreadCount}
+                max={99}
+                sx={{
+                  "& .MuiBadge-badge": {
+                    minWidth: 18,
+                    height: 18,
+                    fontSize: 10,
+                    fontWeight: 700,
+                  },
+                }}
+              />
+            </Box>
           </ToggleButton>
-          <ToggleButton value="encrypted" sx={{ color: "white", flex: 1 }}>
-            Encrypted
+          <ToggleButton
+            value="encrypted"
+            sx={{ color: "white", flex: 1, minWidth: 0, p: 0 }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                width: "100%",
+                minWidth: 0,
+                px: 1.5,
+              }}
+            >
+              <Typography
+                noWrap
+                sx={{
+                  textOverflow: "ellipsis",
+                  overflow: "hidden",
+                  minWidth: 0,
+                  flex: 1,
+                }}
+              >
+                Encrypted
+              </Typography>
+              <Badge
+                color="error"
+                badgeContent={encryptedUnreadCount}
+                invisible={!encryptedUnreadCount}
+                max={99}
+                sx={{
+                  ml: 1,
+                  "& .MuiBadge-badge": {
+                    minWidth: 18,
+                    height: 18,
+                    fontSize: 10,
+                    fontWeight: 700,
+                  },
+                }}
+              />
+            </Box>
           </ToggleButton>
         </ToggleButtonGroup>
       </Box>

--- a/client/src/app/layout/SideNav/DefaultSidebarContent.tsx
+++ b/client/src/app/layout/SideNav/DefaultSidebarContent.tsx
@@ -1,7 +1,9 @@
-import { PeopleAlt } from "@mui/icons-material";
+﻿import { PeopleAlt } from "@mui/icons-material";
 import {
   Badge,
   Box,
+  ToggleButton,
+  ToggleButtonGroup,
   List,
   ListItemButton,
   ListItemIcon,
@@ -13,20 +15,59 @@ import { Link, useLocation } from "react-router";
 import DirectSearchInput from "../../../features/directChats/DirectSearchInput";
 import AvatarWithStatus from "../../shared/components/AvatarWithStatus";
 import { useDirectChats } from "../../../lib/hooks/useDirectChats";
-import { useMemo, useState } from "react";
+import { useEncryptedDirectChats } from "../../../lib/hooks/useEncryptedDirectChats";
+import { useEffect, useMemo, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useStore } from "../../../lib/hooks/useStore";
 import { useFriends } from "../../../lib/hooks/useFriends";
+import type { DirectChat, EncryptedDirectChat } from "../../../lib/types";
+
+type ChatListItem =
+  | { kind: "direct"; chat: DirectChat }
+  | { kind: "encrypted"; chat: EncryptedDirectChat };
 
 const DefaultSidebarContent = observer(function DefaultSidebarContent() {
   const location = useLocation();
   const [query, setQuery] = useState("");
+  const [chatView, setChatView] = useState<"direct" | "encrypted">(() => {
+    const stored = localStorage.getItem("directSidebarView");
+    return stored === "encrypted" ? "encrypted" : "direct";
+  });
   const { directChats } = useDirectChats();
+  const { encryptedDirectChats } = useEncryptedDirectChats();
   const { messagesNotificationsStore } = useStore();
+
+  const handleChatViewChange = (
+    _: React.MouseEvent<HTMLElement>,
+    next: "direct" | "encrypted" | null
+  ) => {
+    if (!next) return;
+    setChatView(next);
+    localStorage.setItem("directSidebarView", next);
+  };
   const { friendRequests } = useFriends();
+  useEffect(() => {
+    if (location.pathname.startsWith("/encrypted-direct-chats")) {
+      setChatView((prev) => {
+        if (prev !== "encrypted") {
+          localStorage.setItem("directSidebarView", "encrypted");
+          return "encrypted";
+        }
+        return prev;
+      });
+    } else if (location.pathname.startsWith("/direct-chats")) {
+      setChatView((prev) => {
+        if (prev !== "direct") {
+          localStorage.setItem("directSidebarView", "direct");
+          return "direct";
+        }
+        return prev;
+      });
+    }
+  }, [location.pathname]);
   const friendInvitesCount = friendRequests?.received?.length || 0;
 
-  const filteredChats = useMemo(() => {
+  const filteredDirectChats = useMemo(() => {
     const q = query.trim().toLowerCase();
     const base = directChats ?? [];
     if (!q) return base;
@@ -34,6 +75,27 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
       (c.otherUserDisplayName ?? "").toLowerCase().includes(q)
     );
   }, [directChats, query]);
+
+  const filteredEncryptedChats = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const base = encryptedDirectChats ?? [];
+    if (!q) return base;
+    return base.filter((c) =>
+      (c.otherUserDisplayName ?? "").toLowerCase().includes(q)
+    );
+  }, [encryptedDirectChats, query]);
+  const chatsToRender = useMemo<ChatListItem[]>(() => {
+    if (chatView === "direct") {
+      return filteredDirectChats.map((chat) => ({
+        kind: "direct" as const,
+        chat,
+      }));
+    }
+    return filteredEncryptedChats.map((chat) => ({
+      kind: "encrypted" as const,
+      chat,
+    }));
+  }, [chatView, filteredDirectChats, filteredEncryptedChats]);
 
   return (
     <>
@@ -78,34 +140,80 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
         </ListItemButton>
       </List>
 
-      <Box sx={{ px: 2, py: 1, display: "flex", alignItems: "center", gap: 1 }}>
-        <Typography variant="subtitle2" color="text.secondary">
-          Direct Messages
-        </Typography>
+      <Box
+        sx={{
+          px: 2,
+          py: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 1,
+        }}
+      >
+        <ToggleButtonGroup
+          value={chatView}
+          exclusive
+          onChange={handleChatViewChange}
+          size="small"
+          sx={{
+            backgroundColor: "rgba(255,255,255,0.04)",
+            flex: 1,
+          }}
+        >
+          <ToggleButton value="direct" sx={{ color: "white", flex: 1 }}>
+            Direct
+          </ToggleButton>
+          <ToggleButton value="encrypted" sx={{ color: "white", flex: 1 }}>
+            Encrypted
+          </ToggleButton>
+        </ToggleButtonGroup>
       </Box>
       <Divider sx={{ borderColor: "rgba(255,255,255,0.08)" }} />
 
       <Box sx={{ flex: 1, overflowY: "auto" }}>
         <List sx={{ py: 0 }}>
-          {filteredChats.map((chat) => {
+          {chatsToRender.map(({ kind, chat }) => {
             const unreadCount =
-              messagesNotificationsStore.directUnreadByChat.get(chat.id) ?? 0;
-            const isReadOnly = !chat.canSendMessages;
+              kind === "direct"
+                ? messagesNotificationsStore.directUnreadByChat.get(chat.id) ??
+                  0
+                : messagesNotificationsStore.encryptedDirectUnreadByChat.get(
+                    chat.id
+                  ) ?? 0;
+            const isReadOnly =
+              kind === "direct" ? !chat.canSendMessages : false;
+            const linkTo =
+              kind === "direct"
+                ? `/direct-chats/${chat.otherUserSlug}`
+                : `/encrypted-direct-chats/${chat.otherUserSlug}`;
+            const isSelected = location.pathname === linkTo;
+            const avatarStatus = chat.status || "Offline";
+            const primaryColor = isReadOnly ? "text.secondary" : "white";
+            const secondaryNode =
+              kind === "direct" ? (
+                chat.lastMessageBody ? (
+                  <Typography variant="caption" color="text.secondary" noWrap>
+                    {chat.lastMessageBody}
+                  </Typography>
+                ) : null
+              ) : chat.lastMessageSenderId ? (
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  Encrypted message
+                </Typography>
+              ) : null;
 
             return (
               <ListItemButton
                 key={chat.id}
                 component={Link}
-                to={`/direct-chats/${chat.otherUserSlug}`}
+                to={linkTo}
                 sx={{
                   borderRadius: 1,
                   mx: 1,
                   my: 0.2,
                   opacity: isReadOnly ? 0.6 : 1,
                 }}
-                selected={
-                  location.pathname === `/direct-chats/${chat.otherUserSlug}`
-                }
+                selected={isSelected}
               >
                 <ListItemIcon sx={{ minWidth: 48 }}>
                   <Badge
@@ -127,7 +235,7 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
                     <AvatarWithStatus
                       src={chat.otherUserImageUrl}
                       alt={chat.otherUserDisplayName}
-                      status={chat.status || "Offline"}
+                      status={avatarStatus}
                       containerSx={
                         isReadOnly ? { filter: "grayscale(100%)" } : undefined
                       }
@@ -139,23 +247,13 @@ const DefaultSidebarContent = observer(function DefaultSidebarContent() {
                 <ListItemText
                   primary={
                     <Typography
-                      color={isReadOnly ? "text.secondary" : "white"}
+                      color={primaryColor}
                       fontWeight={unreadCount ? 700 : undefined}
                     >
                       {chat.otherUserDisplayName}
                     </Typography>
                   }
-                  secondary={
-                    chat.lastMessageBody ? (
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
-                        noWrap
-                      >
-                        {chat.lastMessageBody}
-                      </Typography>
-                    ) : null
-                  }
+                  secondary={secondaryNode}
                 />
               </ListItemButton>
             );

--- a/client/src/app/layout/SideNav/SideNav.tsx
+++ b/client/src/app/layout/SideNav/SideNav.tsx
@@ -95,7 +95,10 @@ const SideNav = observer(function SideNav() {
     };
   }, [fetchNextPage, hasNextPage]);
 
-  const totalDirectUnread = messagesNotificationsStore.totalDirectUnread;
+  const directUnreadCount = messagesNotificationsStore.totalDirectUnread;
+  const encryptedDirectUnreadCount =
+    messagesNotificationsStore.totalEncryptedDirectUnread;
+  const totalDirectBadgeCount = directUnreadCount + encryptedDirectUnreadCount;
   const { friendRequests } = useFriends();
   const friendInvitesCount = friendRequests?.received?.length || 0;
 
@@ -156,8 +159,8 @@ const SideNav = observer(function SideNav() {
             <Badge
               color="error"
               overlap="rectangular"
-              badgeContent={totalDirectUnread}
-              invisible={!totalDirectUnread}
+              badgeContent={totalDirectBadgeCount}
+              invisible={!totalDirectBadgeCount}
               max={99}
               sx={{
                 "& .MuiBadge-badge": {
@@ -333,3 +336,4 @@ const SideNav = observer(function SideNav() {
 });
 
 export default SideNav;
+

--- a/client/src/app/router/Routes.tsx
+++ b/client/src/app/router/Routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate } from "react-router";
+﻿import { createBrowserRouter, Navigate } from "react-router";
 import App from "../layout/App";
 import RequireAuth from "./RequireAuth";
 import NotFound from "../../features/errors/NotFound";
@@ -17,6 +17,7 @@ import Friends from "../../features/friends/Friends";
 import AuthLayout from "../layout/AuthLayout";
 import EmptyPage from "../layout/EmptyPage";
 import DirectChatDetails from "../../features/directChats/DirectChatDetails";
+import EncryptedDirectChatDetails from "../../features/encryptedDirectChats/EncryptedDirectChatDetails";
 
 export const router = createBrowserRouter([
   {
@@ -35,6 +36,10 @@ export const router = createBrowserRouter([
           { path: "profiles/:slug", element: <ProfilePage /> },
           { path: "friends", element: <Friends /> },
           { path: "direct-chats/:userSlug", element: <DirectChatDetails /> },
+          {
+            path: "encrypted-direct-chats/:userSlug",
+            element: <EncryptedDirectChatDetails />,
+          },
           { path: "change-password", element: <ChangePasswordForm /> },
         ],
       },

--- a/client/src/app/shared/components/EmojiSettingsDialog.tsx
+++ b/client/src/app/shared/components/EmojiSettingsDialog.tsx
@@ -19,7 +19,7 @@ import { useEmojiPreferences } from "../../../lib/hooks/useEmojiPreferences";
 type Props = {
   open: boolean;
   onClose: () => void;
-  chatType: "chatroom" | "direct";
+  chatType: "chatroom" | "direct" | "encrypted";
   chatId: string;
   chatName: string;
 };
@@ -60,7 +60,12 @@ export default function EmojiSettingsDialog({
 }: Props) {
   const { useEmojiPreference, setEmojiPreference } = useEmojiPreferences();
 
-  const backendChatType = chatType === "chatroom" ? "ChatRoom" : "DirectChat";
+  const backendChatType =
+    chatType === "chatroom"
+      ? "ChatRoom"
+      : chatType === "encrypted"
+        ? "EncryptedDirectChat"
+        : "DirectChat";
 
   const { data: emojiPreference, isLoading } = useEmojiPreference(
     backendChatType,
@@ -127,7 +132,7 @@ export default function EmojiSettingsDialog({
       <DialogContent>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
           Choose a default emoji for quick reactions in this{" "}
-          {chatType === "chatroom" ? "chat room" : "direct chat"}.
+          {chatType === "chatroom" ? "chat room" : chatType === "encrypted" ? "encrypted chat" : "direct chat"}.
         </Typography>
 
         {/* Current Selection */}
@@ -203,3 +208,4 @@ export default function EmojiSettingsDialog({
     </Dialog>
   );
 }
+

--- a/client/src/app/shared/components/MessagesRealtimeProvider.tsx
+++ b/client/src/app/shared/components/MessagesRealtimeProvider.tsx
@@ -1,11 +1,13 @@
-import { useEffect } from "react";
+﻿import { useEffect } from "react";
 import { autorun } from "mobx";
 import { useMessagesHub } from "../../../lib/hooks/useMessagesHub";
+import { useEncryptedMessagesHub } from "../../../lib/hooks/useEncryptedMessagesHub";
 import { useStore } from "../../../lib/hooks/useStore";
 import notificationsApi from "../../../lib/api/notifications";
 
 export default function MessagesRealtimeProvider() {
   useMessagesHub();
+  useEncryptedMessagesHub();
   const { messagesNotificationsStore } = useStore();
 
   useEffect(() => {
@@ -39,6 +41,13 @@ export default function MessagesRealtimeProvider() {
       const directUnread = activeDirect
         ? messagesNotificationsStore.directUnreadByChat.get(activeDirect) ?? 0
         : 0;
+      const activeEncrypted =
+        messagesNotificationsStore.activeEncryptedDirectChatId;
+      const encryptedUnread = activeEncrypted
+        ? messagesNotificationsStore.encryptedDirectUnreadByChat.get(
+            activeEncrypted
+          ) ?? 0
+        : 0;
 
       messagesNotificationsStore.setWindowFocused(true);
 
@@ -47,6 +56,11 @@ export default function MessagesRealtimeProvider() {
       }
       if (activeDirect && directUnread > 0) {
         notificationsApi.markDirectChatRead(activeDirect).catch(() => {});
+      }
+      if (activeEncrypted && encryptedUnread > 0) {
+        notificationsApi
+          .markEncryptedDirectChatRead(activeEncrypted)
+          .catch(() => {});
       }
     };
 

--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -76,10 +76,19 @@ const MediaChatComponent = observer(function MediaChatComponent({
     | undefined
   >(undefined);
 
-  const chatType = chatRoomId ? "ChatRoom" : "DirectChat";
-  const chatId = chatRoomId || encryptedDirectChatId || directChatId || "";
+  const backendChatType = chatRoomId
+    ? "ChatRoom"
+    : encryptedDirectChatId
+      ? "EncryptedDirectChat"
+      : "DirectChat";
+  const chatId = chatRoomId ?? encryptedDirectChatId ?? directChatId ?? "";
+  const settingsDialogChatType = chatRoomId
+    ? "chatroom"
+    : encryptedDirectChatId
+      ? "encrypted"
+      : "direct";
   const { useEmojiPreference } = useEmojiPreferences();
-  const { data: emojiPreference } = useEmojiPreference(chatType, chatId);
+  const { data: emojiPreference } = useEmojiPreference(backendChatType, chatId);
   const defaultEmoji = emojiPreference?.defaultEmoji || "\u{1F44D}";
 
   const scrollHandler = useScrollHandler({ messageStore });
@@ -429,7 +438,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
       <EmojiSettingsDialog
         open={showEmojiSettings}
         onClose={() => setShowEmojiSettings(false)}
-        chatType={chatRoomId ? "chatroom" : "direct"}
+        chatType={settingsDialogChatType}
         chatId={chatId}
         chatName={title}
       />
@@ -438,3 +447,4 @@ const MediaChatComponent = observer(function MediaChatComponent({
 });
 
 export default MediaChatComponent;
+

--- a/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/MediaChatComponent.tsx
@@ -37,6 +37,7 @@ interface MediaChatComponentProps {
   showUserProfiles?: boolean;
   chatRoomId?: string;
   directChatId?: string;
+  encryptedDirectChatId?: string;
   userPermissions?: ReturnType<
     typeof useChatRoomRolesRealtime
   >["userPermissions"];
@@ -50,6 +51,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
   showUserProfiles = true,
   chatRoomId,
   directChatId,
+  encryptedDirectChatId,
   userPermissions,
   directCanSend,
 }: MediaChatComponentProps) {
@@ -75,10 +77,10 @@ const MediaChatComponent = observer(function MediaChatComponent({
   >(undefined);
 
   const chatType = chatRoomId ? "ChatRoom" : "DirectChat";
-  const chatId = chatRoomId || directChatId || "";
+  const chatId = chatRoomId || encryptedDirectChatId || directChatId || "";
   const { useEmojiPreference } = useEmojiPreferences();
   const { data: emojiPreference } = useEmojiPreference(chatType, chatId);
-  const defaultEmoji = emojiPreference?.defaultEmoji || "👍";
+  const defaultEmoji = emojiPreference?.defaultEmoji || "\u{1F44D}";
 
   const scrollHandler = useScrollHandler({ messageStore });
   const fileUpload = useFileUpload({
@@ -267,6 +269,7 @@ const MediaChatComponent = observer(function MediaChatComponent({
                 onJumpToMessage={handleJumpToMessage}
                 chatRoomId={chatRoomId}
                 directChatId={directChatId}
+                encryptedDirectChatId={encryptedDirectChatId}
                 defaultEmoji={defaultEmoji}
               />
             </Box>

--- a/client/src/app/shared/components/mediaChatComponent/chatMessageList/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/chatMessageList/ChatMessageList.tsx
@@ -37,6 +37,7 @@ interface ChatMessageListProps {
   chatRoomId?: string;
   defaultEmoji?: string;
   directChatId?: string;
+  encryptedDirectChatId?: string;
 }
 
 export default function ChatMessageList({
@@ -51,6 +52,7 @@ export default function ChatMessageList({
   chatRoomId,
   defaultEmoji = "👍",
   directChatId,
+  encryptedDirectChatId,
 }: ChatMessageListProps) {
   const { currentUser } = useAccount();
   const renderItems: RenderItem[] = buildRenderItems(
@@ -63,7 +65,11 @@ export default function ChatMessageList({
   // - invoke SignalR hub ("ToggleMessageReaction" or "ToggleDirectMessageReaction")
   // - if remote call fails, roll back local change
   const toggleReactionOptimistic = async (messageId: string, emoji: string) => {
-    if ((!chatRoomId && !directChatId) || !currentUser) return;
+    if (
+      (!chatRoomId && !directChatId && !encryptedDirectChatId) ||
+      !currentUser
+    )
+      return;
 
     const key = `${messageId}|${emoji}`;
     if (inFlightRef.current.has(key)) return;
@@ -113,6 +119,13 @@ export default function ChatMessageList({
         await (messageStore.hubConnection as HubConnection)?.invoke(
           "ToggleDirectMessageReaction",
           directChatId,
+          messageId,
+          emoji
+        );
+      } else if (encryptedDirectChatId) {
+        await (messageStore.hubConnection as HubConnection)?.invoke(
+          "ToggleEncryptedMessageReaction",
+          encryptedDirectChatId,
           messageId,
           emoji
         );
@@ -205,7 +218,9 @@ export default function ChatMessageList({
               onReplyClick={onReplyClick}
               onJumpToMessage={onJumpToMessage}
               defaultEmoji={defaultEmoji}
-              showEmoji={Boolean(chatRoomId || directChatId)}
+              showEmoji={Boolean(
+                chatRoomId || directChatId || encryptedDirectChatId
+              )}
               onToggleReaction={(emoji) =>
                 toggleReactionOptimistic(message.id, emoji)
               }
@@ -308,7 +323,7 @@ export default function ChatMessageList({
                   )}
 
                   {/* Emoji picker for adding reactions to the message */}
-                  {(chatRoomId || directChatId) && (
+                  {(chatRoomId || directChatId || encryptedDirectChatId) && (
                     <EmojiPickerComponent
                       variant="reaction"
                       showQuickReact={false}

--- a/client/src/features/account/LoginForm.tsx
+++ b/client/src/features/account/LoginForm.tsx
@@ -87,6 +87,7 @@ export default function LoginForm() {
       <Paper
         component="form"
         onSubmit={handleSubmit(onSubmit)}
+        autoComplete="on"
         sx={{
           display: "flex",
           flexDirection: "column",
@@ -144,6 +145,7 @@ export default function LoginForm() {
               control={control}
               name="email"
               tabIndex={1}
+              autoComplete="username"
             />
           </Box>
 
@@ -181,6 +183,7 @@ export default function LoginForm() {
               control={control}
               name="password"
               tabIndex={2}
+              autoComplete="current-password"
             />
           </Box>
         </Box>

--- a/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
+++ b/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
@@ -234,6 +234,9 @@ const EncryptedDirectChatDetails = observer(
       width: number;
     } | null>(null);
 
+    const sidebarRef = useRef<HTMLDivElement | null>(null);
+    const rafRef = useRef<number | null>(null);
+
     const resetRightPanel = () => {
       setRightPanelWidth(DEFAULT_RIGHT_PANEL_WIDTH);
       localStorage.setItem(STORAGE_KEY, String(DEFAULT_RIGHT_PANEL_WIDTH));
@@ -245,6 +248,13 @@ const EncryptedDirectChatDetails = observer(
         startWidth: rightPanelWidth,
         width: rightPanelWidth,
       };
+
+      const applyWidth = (w: number) => {
+        if (sidebarRef.current) {
+          sidebarRef.current.style.width = `${w}px`;
+        }
+      };
+
       const onMove = (ev: MouseEvent) => {
         if (!dragStateRef.current) return;
         const dx = dragStateRef.current.startX - ev.clientX;
@@ -253,17 +263,36 @@ const EncryptedDirectChatDetails = observer(
           640
         );
         dragStateRef.current.width = next;
-        setRightPanelWidth(next);
+
+        if (rafRef.current == null) {
+          rafRef.current = requestAnimationFrame(() => {
+            rafRef.current = null;
+            if (dragStateRef.current) applyWidth(dragStateRef.current.width);
+          });
+        }
       };
+
       const onUp = () => {
         document.removeEventListener("mousemove", onMove);
         document.removeEventListener("mouseup", onUp);
+
+        if (rafRef.current != null) {
+          cancelAnimationFrame(rafRef.current);
+          rafRef.current = null;
+        }
         const width = dragStateRef.current?.width ?? rightPanelWidth;
         dragStateRef.current = null;
+        setRightPanelWidth(width);
         localStorage.setItem(STORAGE_KEY, String(width));
+
+        if (sidebarRef.current) {
+          sidebarRef.current.style.width = "";
+        }
+
         document.body.style.cursor = "";
         (document.body.style as CSSStyleDeclaration).userSelect = "";
       };
+
       document.addEventListener("mousemove", onMove);
       document.addEventListener("mouseup", onUp);
       document.body.style.cursor = "col-resize";
@@ -578,6 +607,7 @@ const EncryptedDirectChatDetails = observer(
                 }}
               />
               <Box
+                ref={sidebarRef}
                 sx={{
                   width: rightPanelWidth,
                   flexShrink: 0,

--- a/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
+++ b/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { observer, useLocalObservable } from "mobx-react-lite";
 import { reaction, runInAction } from "mobx";
 import {
@@ -11,10 +11,9 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  Tooltip,
   Typography,
 } from "@mui/material";
-import { Lock, LockOpen } from "@mui/icons-material";
+import { Lock, LockOpen, MoreHoriz } from "@mui/icons-material";
 import AvatarWithStatus from "../../app/shared/components/AvatarWithStatus";
 import EmojiSettingsDialog from "../../app/shared/components/EmojiSettingsDialog";
 import MediaChatComponent from "../../app/shared/components/mediaChatComponent/MediaChatComponent";
@@ -220,6 +219,56 @@ const EncryptedDirectChatDetails = observer(
     const [passphraseInput, setPassphraseInput] = useState("");
     const [passphraseBusy, setPassphraseBusy] = useState(false);
     const [passphraseError, setPassphraseError] = useState<string | null>(null);
+    const [rightPanelOpen, setRightPanelOpen] = useState(true);
+    const DEFAULT_RIGHT_PANEL_WIDTH = 300;
+    const STORAGE_KEY = "encryptedDirectRightPanelWidth";
+    const [rightPanelWidth, setRightPanelWidth] = useState<number>(() => {
+      const saved = Number(localStorage.getItem(STORAGE_KEY));
+      return Number.isFinite(saved) && saved > 0
+        ? saved
+        : DEFAULT_RIGHT_PANEL_WIDTH;
+    });
+    const dragStateRef = useRef<{
+      startX: number;
+      startWidth: number;
+      width: number;
+    } | null>(null);
+
+    const resetRightPanel = () => {
+      setRightPanelWidth(DEFAULT_RIGHT_PANEL_WIDTH);
+      localStorage.setItem(STORAGE_KEY, String(DEFAULT_RIGHT_PANEL_WIDTH));
+    };
+
+    const startResize = (e: React.MouseEvent) => {
+      dragStateRef.current = {
+        startX: e.clientX,
+        startWidth: rightPanelWidth,
+        width: rightPanelWidth,
+      };
+      const onMove = (ev: MouseEvent) => {
+        if (!dragStateRef.current) return;
+        const dx = dragStateRef.current.startX - ev.clientX;
+        const next = Math.min(
+          Math.max(dragStateRef.current.startWidth + dx, 220),
+          640
+        );
+        dragStateRef.current.width = next;
+        setRightPanelWidth(next);
+      };
+      const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+        const width = dragStateRef.current?.width ?? rightPanelWidth;
+        dragStateRef.current = null;
+        localStorage.setItem(STORAGE_KEY, String(width));
+        document.body.style.cursor = "";
+        (document.body.style as CSSStyleDeclaration).userSelect = "";
+      };
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+      document.body.style.cursor = "col-resize";
+      (document.body.style as CSSStyleDeclaration).userSelect = "none";
+    };
 
     const messageViewStore = useLocalObservable<BaseMessageStore>(() => ({
       messages: [] as BaseMessage[],
@@ -433,87 +482,197 @@ const EncryptedDirectChatDetails = observer(
     };
 
     return (
-      <Box
-        sx={{
-          height: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          overflow: "hidden",
-        }}
-      >
+      <>
         <Box
           sx={{
+            height: "100vh",
             display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            borderBottom: "1px solid",
-            borderColor: "divider",
-            p: 1.5,
+            flexDirection: "row",
+            overflow: "hidden",
           }}
         >
-          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-            <AvatarWithStatus
-              src={currentChat.otherUserImageUrl}
-              alt={currentChat.otherUserDisplayName}
-              status={
-                currentChat.status ||
-                (currentChat.isOnline ? "Online" : "Offline")
-              }
+          <Box
+            sx={{
+              flex: rightPanelOpen
+                ? `1 1 calc(100% - ${rightPanelWidth}px)`
+                : "1 1 100%",
+              display: "flex",
+              flexDirection: "column",
+              minWidth: 0,
+              transition: "flex-basis 200ms cubic-bezier(.4,0,.2,1)",
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                borderBottom: "1px solid",
+                borderColor: "divider",
+                p: 1.5,
+              }}
             >
-              {currentChat.otherUserDisplayName?.charAt(0).toUpperCase()}
-            </AvatarWithStatus>
-            <Box>
-              <Typography variant="h6" fontWeight="bold">
-                {currentChat.otherUserDisplayName}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                Encrypted conversation
-              </Typography>
-            </Box>
-          </Box>
-          <Box sx={{ display: "flex", gap: 1 }}>
-            <Tooltip
-              title={cryptoKey ? "Clear stored passphrase" : "Set passphrase"}
-            >
-              <span>
-                <IconButton
-                  color={cryptoKey ? "warning" : "primary"}
-                  onClick={
-                    cryptoKey
-                      ? handleClearPassphrase
-                      : handleOpenPassphraseDialog
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                <AvatarWithStatus
+                  src={currentChat.otherUserImageUrl}
+                  alt={currentChat.otherUserDisplayName}
+                  status={
+                    currentChat.status ||
+                    (currentChat.isOnline ? "Online" : "Offline")
                   }
                 >
-                  {cryptoKey ? <LockOpen /> : <Lock />}
-                </IconButton>
-              </span>
-            </Tooltip>
-            <Button variant="outlined" onClick={handleOpenPassphraseDialog}>
-              {cryptoKey ? "Update passphrase" : "Set passphrase"}
-            </Button>
-            <Button variant="outlined" onClick={() => setEmojiDialogOpen(true)}>
-              Change default emoji
-            </Button>
+                  {currentChat.otherUserDisplayName?.charAt(0).toUpperCase()}
+                </AvatarWithStatus>
+                <Box>
+                  <Typography variant="h6" fontWeight="bold">
+                    {currentChat.otherUserDisplayName}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Encrypted conversation
+                  </Typography>
+                </Box>
+              </Box>
+              <IconButton
+                aria-label="Conversation options"
+                onClick={() => setRightPanelOpen((open) => !open)}
+              >
+                <MoreHoriz />
+              </IconButton>
+            </Box>
+
+            {!cryptoKey && (
+              <Alert severity="info" sx={{ m: 2 }}>
+                Set a shared passphrase to decrypt messages in this
+                conversation.
+              </Alert>
+            )}
+
+            <Box sx={{ flex: 1, minHeight: 0 }}>
+              <MediaChatComponent
+                title={`Chat with ${currentChat.otherUserDisplayName}`}
+                messageStore={messageViewStore}
+                onSendMessage={handleSendMessage}
+                showUserProfiles
+                chatRoomId={undefined}
+                directChatId={undefined}
+                encryptedDirectChatId={encryptedDirectChatId}
+                directCanSend={Boolean(cryptoKey)}
+              />
+            </Box>
           </Box>
-        </Box>
 
-        {!cryptoKey && (
-          <Alert severity="info" sx={{ m: 2 }}>
-            Set a shared passphrase to decrypt messages in this conversation.
-          </Alert>
-        )}
-
-        <Box sx={{ flex: 1, minHeight: 0 }}>
-          <MediaChatComponent
-            title={`Chat with ${currentChat.otherUserDisplayName}`}
-            messageStore={messageViewStore}
-            onSendMessage={handleSendMessage}
-            showUserProfiles
-            chatRoomId={undefined}
-            directChatId={undefined}
-            encryptedDirectChatId={encryptedDirectChatId}
-            directCanSend={Boolean(cryptoKey)}
-          />
+          {rightPanelOpen && (
+            <>
+              <Box
+                role="separator"
+                aria-orientation="vertical"
+                onMouseDown={startResize}
+                onDoubleClick={resetRightPanel}
+                sx={{
+                  width: 4,
+                  cursor: "col-resize",
+                  flex: "0 0 4px",
+                  alignSelf: "stretch",
+                  bgcolor: "divider",
+                  "&:hover": { bgcolor: "action.hover" },
+                }}
+              />
+              <Box
+                sx={{
+                  width: rightPanelWidth,
+                  flexShrink: 0,
+                  p: 2,
+                  boxSizing: "border-box",
+                  bgcolor: "background.paper",
+                  borderLeft: "1px solid",
+                  borderColor: "divider",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 3,
+                  overflowY: "auto",
+                }}
+              >
+                <Typography variant="h6">Conversation Options</Typography>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Encryption
+                    </Typography>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        mt: 1,
+                      }}
+                    >
+                      {cryptoKey ? (
+                        <>
+                          <Lock sx={{ fontSize: 20, color: "success.main" }} />
+                          <Typography variant="body2" color="text.secondary">
+                            Passphrase stored on this device.
+                          </Typography>
+                        </>
+                      ) : (
+                        <>
+                          <LockOpen
+                            sx={{ fontSize: 20, color: "warning.main" }}
+                          />
+                          <Typography variant="body2" color="text.secondary">
+                            Set the shared passphrase to unlock messages.
+                          </Typography>
+                        </>
+                      )}
+                    </Box>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        gap: 1,
+                        mt: 1.5,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Button
+                        variant="contained"
+                        onClick={handleOpenPassphraseDialog}
+                      >
+                        {cryptoKey ? "Update passphrase" : "Set passphrase"}
+                      </Button>
+                      {cryptoKey && (
+                        <Button
+                          color="warning"
+                          variant="outlined"
+                          onClick={handleClearPassphrase}
+                        >
+                          Clear passphrase
+                        </Button>
+                      )}
+                    </Box>
+                  </Box>
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Default Emoji
+                    </Typography>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mt: 1 }}
+                    >
+                      Choose the default reaction emoji for this encrypted
+                      conversation.
+                    </Typography>
+                    <Button
+                      variant="outlined"
+                      sx={{ mt: 1.5 }}
+                      onClick={() => setEmojiDialogOpen(true)}
+                    >
+                      Change default emoji
+                    </Button>
+                  </Box>
+                </Box>
+              </Box>
+            </>
+          )}
         </Box>
 
         <Dialog
@@ -567,10 +726,9 @@ const EncryptedDirectChatDetails = observer(
             chatName={`Chat with ${currentChat.otherUserDisplayName}`}
           />
         )}
-      </Box>
+      </>
     );
   }
 );
 
 export default EncryptedDirectChatDetails;
-

--- a/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
+++ b/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
@@ -1,0 +1,561 @@
+import { useParams } from "react-router";
+import { useEffect, useMemo, useState } from "react";
+import { observer, useLocalObservable } from "mobx-react-lite";
+import { reaction, runInAction } from "mobx";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Lock, LockOpen } from "@mui/icons-material";
+import AvatarWithStatus from "../../app/shared/components/AvatarWithStatus";
+import MediaChatComponent from "../../app/shared/components/mediaChatComponent/MediaChatComponent";
+import { useEncryptedDirectChats } from "../../lib/hooks/useEncryptedDirectChats";
+import { useEncryptedDirectMessages } from "../../lib/hooks/useEncryptedDirectMessages";
+import {
+  decryptMessageMetadata,
+  decryptMessagePayload,
+  deriveChatKey,
+  encryptMessagePayload,
+  exportKeyToStorage,
+  loadKeyFromStorage,
+  clearStoredKey,
+} from "../../lib/crypto/encryptedChat";
+import type {
+  BaseMessage,
+  BaseMessageStore,
+  EncryptedDirectMessage,
+  MediaUploadResult,
+  MessageType,
+} from "../../lib/types";
+import { toast } from "react-toastify";
+import TextField from "@mui/material/TextField";
+
+const UNDECRYPTABLE_TEXT = "Unable to decrypt message with current passphrase.";
+const PASSPHRASE_REQUIRED_TEXT =
+  "Set the shared passphrase to decrypt this message.";
+
+type SerializedMediaMetadata = {
+  url?: string;
+  publicId?: string;
+  mediaType?: string;
+  fileSize?: number;
+  originalFileName?: string;
+  messageType?: MessageType;
+};
+
+type EncryptedMessageMetadata = {
+  media?: SerializedMediaMetadata;
+};
+
+function parseContent(raw: string): { body: string } {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.body === "string"
+    ) {
+      return { body: parsed.body };
+    }
+  } catch {
+    // ignore parse error
+  }
+  return { body: raw };
+}
+
+function parseMetadata(raw: string): EncryptedMessageMetadata {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as EncryptedMessageMetadata;
+    }
+  } catch {
+    // ignore parse error
+  }
+  return {};
+}
+
+function mapMimeToMessageType(mediaType?: string): MessageType | undefined {
+  if (!mediaType) return undefined;
+  if (mediaType.startsWith("image/")) return "Image";
+  if (mediaType.startsWith("video/")) return "Video";
+  if (mediaType.startsWith("audio/")) return "Audio";
+  return "Document";
+}
+
+async function buildBaseMessage(
+  message: EncryptedDirectMessage,
+  key: CryptoKey | null
+): Promise<BaseMessage> {
+  const createdAt =
+    message.createdAt instanceof Date
+      ? message.createdAt
+      : new Date(message.createdAt);
+
+  const reactions = (message.reactions ?? []).map((reaction) => ({
+    ...reaction,
+    createdAt: reaction.createdAt ? new Date(reaction.createdAt) : new Date(),
+  }));
+
+  const base: BaseMessage = {
+    id: message.id,
+    createdAt,
+    body: key ? UNDECRYPTABLE_TEXT : PASSPHRASE_REQUIRED_TEXT,
+    type: (message.type || "Text") as MessageType,
+    senderId: message.senderId,
+    senderDisplayName: message.senderDisplayName,
+    senderImageUrl: message.senderImageUrl ?? undefined,
+    reactions,
+  };
+
+  if (!key) {
+    if (message.replyToMessageId) {
+      base.replyToMessageId = message.replyToMessageId;
+      base.replyToDisplayName = message.replyToSenderDisplayName ?? undefined;
+      base.replyToBody = PASSPHRASE_REQUIRED_TEXT;
+    }
+    return base;
+  }
+
+  try {
+    const decrypted = await decryptMessagePayload(key, message.cipherText);
+    const content = parseContent(decrypted);
+    base.body = content.body;
+  } catch {
+    base.body = UNDECRYPTABLE_TEXT;
+  }
+
+  if (message.cipherTextMetadata) {
+    try {
+      const decryptedMetadata = await decryptMessageMetadata(
+        key,
+        message.cipherTextMetadata
+      );
+      const metadata = parseMetadata(decryptedMetadata);
+      if (metadata.media) {
+        const media = metadata.media;
+        base.mediaUrl = media.url;
+        base.mediaPublicId = media.publicId;
+        base.mediaType = media.mediaType;
+        base.mediaFileSize = media.fileSize;
+        base.mediaOriginalFileName = media.originalFileName;
+        if (media.messageType) {
+          base.type = media.messageType;
+        }
+      }
+    } catch {
+      // ignore metadata errors
+    }
+  }
+
+  if (message.replyToMessageId) {
+    base.replyToMessageId = message.replyToMessageId;
+    base.replyToDisplayName = message.replyToSenderDisplayName ?? undefined;
+
+    if (message.replyToCipherText) {
+      try {
+        const replyPlain = await decryptMessagePayload(
+          key,
+          message.replyToCipherText
+        );
+        const replyContent = parseContent(replyPlain);
+        base.replyToBody = replyContent.body;
+      } catch {
+        base.replyToBody = UNDECRYPTABLE_TEXT;
+      }
+    } else {
+      base.replyToBody = UNDECRYPTABLE_TEXT;
+    }
+
+    if (message.replyToCipherTextMetadata) {
+      try {
+        const decryptedReplyMetadata = await decryptMessageMetadata(
+          key,
+          message.replyToCipherTextMetadata
+        );
+        const replyMetadata = parseMetadata(decryptedReplyMetadata);
+        if (replyMetadata.media) {
+          const media = replyMetadata.media;
+          base.replyToMediaOriginalFileName = media.originalFileName;
+          if (media.messageType) {
+            base.replyToType = media.messageType;
+          } else if (media.mediaType) {
+            base.replyToType = mapMimeToMessageType(media.mediaType);
+          }
+        }
+      } catch {
+        // ignore reply metadata errors
+      }
+    }
+  }
+
+  return base;
+}
+
+const EncryptedDirectChatDetails = observer(
+  function EncryptedDirectChatDetails() {
+    const { userSlug } = useParams();
+    const { encryptedDirectChats } = useEncryptedDirectChats();
+    const currentChat = useMemo(
+      () =>
+        encryptedDirectChats.find((chat) => chat.otherUserSlug === userSlug),
+      [encryptedDirectChats, userSlug]
+    );
+    const encryptedDirectChatId = currentChat?.id;
+    const { encryptedDirectMessageStore } = useEncryptedDirectMessages(
+      encryptedDirectChatId
+    );
+    const [cryptoKey, setCryptoKey] = useState<CryptoKey | null>(null);
+    const [passphraseDialogOpen, setPassphraseDialogOpen] = useState(false);
+    const [passphraseInput, setPassphraseInput] = useState("");
+    const [passphraseBusy, setPassphraseBusy] = useState(false);
+    const [passphraseError, setPassphraseError] = useState<string | null>(null);
+
+    const messageViewStore = useLocalObservable<BaseMessageStore>(() => ({
+      messages: [] as BaseMessage[],
+      hasOlderMessages: false,
+      isLoadingOlder: false,
+      loadOlderMessages: () => {
+        encryptedDirectMessageStore.loadOlderMessages();
+      },
+      hubConnection: encryptedDirectMessageStore.hubConnection as unknown,
+    }));
+
+    useEffect(() => {
+      if (!encryptedDirectChatId) {
+        setCryptoKey(null);
+        runInAction(() => {
+          messageViewStore.messages = [];
+        });
+        return;
+      }
+
+      let mounted = true;
+      loadKeyFromStorage(encryptedDirectChatId).then((key) => {
+        if (mounted) {
+          setCryptoKey(key);
+        }
+      });
+
+      return () => {
+        mounted = false;
+      };
+    }, [encryptedDirectChatId, messageViewStore]);
+
+    useEffect(() => {
+      const dispose = reaction(
+        () => ({
+          hasOlder: encryptedDirectMessageStore.hasOlderMessages,
+          isLoadingOlder: encryptedDirectMessageStore.isLoadingOlder,
+          hub: encryptedDirectMessageStore.hubConnection,
+        }),
+        ({ hasOlder, isLoadingOlder, hub }) => {
+          runInAction(() => {
+            messageViewStore.hasOlderMessages = hasOlder;
+            messageViewStore.isLoadingOlder = isLoadingOlder;
+            messageViewStore.hubConnection = hub as unknown;
+          });
+        },
+        { fireImmediately: true }
+      );
+
+      return () => {
+        dispose();
+      };
+    }, [encryptedDirectMessageStore, messageViewStore]);
+
+    useEffect(() => {
+      if (!encryptedDirectChatId) {
+        runInAction(() => {
+          messageViewStore.messages = [];
+        });
+        return;
+      }
+
+      let cancelled = false;
+
+      const dispose = reaction(
+        () =>
+          encryptedDirectMessageStore.messages.map((m) => ({
+            id: m.id,
+            cipherText: m.cipherText,
+            cipherTextMetadata: m.cipherTextMetadata,
+            replyCipher: m.replyToCipherText,
+            replyCipherMetadata: m.replyToCipherTextMetadata,
+            createdAt:
+              m.createdAt instanceof Date
+                ? m.createdAt.getTime()
+                : new Date(m.createdAt).getTime(),
+            reactionsSignature: JSON.stringify(
+              (m.reactions ?? []).map(
+                (r) => `${r.userId}:${r.emoji}:${r.createdAt ?? ""}`
+              )
+            ),
+          })),
+        async () => {
+          const snapshot = encryptedDirectMessageStore.messages.slice();
+          const decrypted = await Promise.all(
+            snapshot.map((message) => buildBaseMessage(message, cryptoKey))
+          );
+          if (cancelled) return;
+          const sorted = decrypted.sort(
+            (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+          );
+          runInAction(() => {
+            messageViewStore.messages = sorted;
+          });
+        },
+        { fireImmediately: true }
+      );
+
+      return () => {
+        cancelled = true;
+        dispose();
+      };
+    }, [
+      cryptoKey,
+      encryptedDirectChatId,
+      encryptedDirectMessageStore,
+      messageViewStore,
+    ]);
+
+    if (!currentChat) {
+      return <Typography>Encrypted direct chat not found</Typography>;
+    }
+
+    const handleOpenPassphraseDialog = () => {
+      setPassphraseError(null);
+      setPassphraseInput("");
+      setPassphraseDialogOpen(true);
+    };
+
+    const handleSavePassphrase = async () => {
+      if (!encryptedDirectChatId) return;
+      if (!passphraseInput.trim()) {
+        setPassphraseError("Passphrase cannot be empty");
+        return;
+      }
+      setPassphraseBusy(true);
+      try {
+        const key = await deriveChatKey(
+          passphraseInput.trim(),
+          encryptedDirectChatId
+        );
+        await exportKeyToStorage(encryptedDirectChatId, key);
+        setCryptoKey(key);
+        setPassphraseDialogOpen(false);
+        setPassphraseInput("");
+        setPassphraseError(null);
+        toast.success("Passphrase stored for this chat");
+      } catch (error) {
+        setPassphraseError("Failed to derive key");
+        if (import.meta.env.DEV) console.error("Passphrase error", error);
+      } finally {
+        setPassphraseBusy(false);
+      }
+    };
+
+    const handleClearPassphrase = () => {
+      if (!encryptedDirectChatId) return;
+      clearStoredKey(encryptedDirectChatId);
+      setCryptoKey(null);
+      setPassphraseInput("");
+      toast.info("Cleared stored passphrase for this chat");
+    };
+
+    const handleSendMessage = async (
+      body: string,
+      type: MessageType = "Text",
+      mediaData?: Partial<MediaUploadResult>,
+      replyToMessageId?: string
+    ) => {
+      if (!encryptedDirectChatId) {
+        throw new Error("Missing chat context");
+      }
+      if (!cryptoKey) {
+        setPassphraseDialogOpen(true);
+        throw new Error("Passphrase required");
+      }
+      if (!encryptedDirectMessageStore.hubConnection) {
+        toast.error("Connection is not ready yet");
+        throw new Error("Hub connection not available");
+      }
+
+      const normalizedBody = typeof body === "string" ? body : "";
+      const metadataPayload = mediaData
+        ? {
+            media: {
+              url: mediaData.url,
+              publicId: mediaData.publicId,
+              mediaType: mediaData.mediaType,
+              fileSize: mediaData.fileSize,
+              originalFileName: mediaData.originalFileName,
+              messageType: type,
+            },
+          }
+        : undefined;
+
+      try {
+        const { cipherText, metadata } = await encryptMessagePayload(
+          cryptoKey,
+          JSON.stringify({ body: normalizedBody }),
+          metadataPayload ? JSON.stringify(metadataPayload) : undefined
+        );
+
+        await encryptedDirectMessageStore.hubConnection.invoke(
+          "SendEncryptedMessage",
+          {
+            encryptedDirectChatId,
+            cipherText,
+            cipherTextMetadata: metadata,
+            version: "v1",
+            type,
+            ...(replyToMessageId ? { replyToMessageId } : {}),
+          }
+        );
+      } catch (error) {
+        toast.error("Failed to send encrypted message");
+        if (import.meta.env.DEV) {
+          console.error("Send encrypted message error", error);
+        }
+        throw error instanceof Error ? error : new Error("Send failed");
+      }
+    };
+
+    return (
+      <Box
+        sx={{
+          height: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            p: 1.5,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+            <AvatarWithStatus
+              src={currentChat.otherUserImageUrl}
+              alt={currentChat.otherUserDisplayName}
+              status={
+                currentChat.status ||
+                (currentChat.isOnline ? "Online" : "Offline")
+              }
+            >
+              {currentChat.otherUserDisplayName?.charAt(0).toUpperCase()}
+            </AvatarWithStatus>
+            <Box>
+              <Typography variant="h6" fontWeight="bold">
+                {currentChat.otherUserDisplayName}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Encrypted conversation
+              </Typography>
+            </Box>
+          </Box>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Tooltip
+              title={cryptoKey ? "Clear stored passphrase" : "Set passphrase"}
+            >
+              <span>
+                <IconButton
+                  color={cryptoKey ? "warning" : "primary"}
+                  onClick={
+                    cryptoKey
+                      ? handleClearPassphrase
+                      : handleOpenPassphraseDialog
+                  }
+                >
+                  {cryptoKey ? <LockOpen /> : <Lock />}
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Button variant="outlined" onClick={handleOpenPassphraseDialog}>
+              {cryptoKey ? "Update passphrase" : "Set passphrase"}
+            </Button>
+          </Box>
+        </Box>
+
+        {!cryptoKey && (
+          <Alert severity="info" sx={{ m: 2 }}>
+            Set a shared passphrase to decrypt messages in this conversation.
+          </Alert>
+        )}
+
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <MediaChatComponent
+            title={`Chat with ${currentChat.otherUserDisplayName}`}
+            messageStore={messageViewStore}
+            onSendMessage={handleSendMessage}
+            showUserProfiles
+            chatRoomId={undefined}
+            directChatId={undefined}
+            encryptedDirectChatId={encryptedDirectChatId}
+            directCanSend={Boolean(cryptoKey)}
+          />
+        </Box>
+
+        <Dialog
+          open={passphraseDialogOpen}
+          onClose={() => !passphraseBusy && setPassphraseDialogOpen(false)}
+        >
+          <DialogTitle>
+            {cryptoKey ? "Update passphrase" : "Set passphrase"}
+          </DialogTitle>
+          <DialogContent
+            sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              Enter a shared passphrase known only to you and{" "}
+              {currentChat.otherUserDisplayName}. This passphrase never leaves
+              your device.
+            </Typography>
+            <TextField
+              label="Passphrase"
+              type="password"
+              value={passphraseInput}
+              onChange={(e) => setPassphraseInput(e.target.value)}
+              error={!!passphraseError}
+              helperText={passphraseError}
+              autoFocus
+              fullWidth
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => !passphraseBusy && setPassphraseDialogOpen(false)}
+              disabled={passphraseBusy}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSavePassphrase}
+              disabled={passphraseBusy}
+              variant="contained"
+            >
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    );
+  }
+);
+
+export default EncryptedDirectChatDetails;

--- a/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
+++ b/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import { Lock, LockOpen } from "@mui/icons-material";
 import AvatarWithStatus from "../../app/shared/components/AvatarWithStatus";
+import EmojiSettingsDialog from "../../app/shared/components/EmojiSettingsDialog";
 import MediaChatComponent from "../../app/shared/components/mediaChatComponent/MediaChatComponent";
 import { useEncryptedDirectChats } from "../../lib/hooks/useEncryptedDirectChats";
 import { useEncryptedDirectMessages } from "../../lib/hooks/useEncryptedDirectMessages";
@@ -214,6 +215,7 @@ const EncryptedDirectChatDetails = observer(
       encryptedDirectChatId
     );
     const [cryptoKey, setCryptoKey] = useState<CryptoKey | null>(null);
+    const [emojiDialogOpen, setEmojiDialogOpen] = useState(false);
     const [passphraseDialogOpen, setPassphraseDialogOpen] = useState(false);
     const [passphraseInput, setPassphraseInput] = useState("");
     const [passphraseBusy, setPassphraseBusy] = useState(false);
@@ -489,6 +491,9 @@ const EncryptedDirectChatDetails = observer(
             <Button variant="outlined" onClick={handleOpenPassphraseDialog}>
               {cryptoKey ? "Update passphrase" : "Set passphrase"}
             </Button>
+            <Button variant="outlined" onClick={() => setEmojiDialogOpen(true)}>
+              Change default emoji
+            </Button>
           </Box>
         </Box>
 
@@ -553,9 +558,19 @@ const EncryptedDirectChatDetails = observer(
             </Button>
           </DialogActions>
         </Dialog>
+        {encryptedDirectChatId && (
+          <EmojiSettingsDialog
+            open={emojiDialogOpen}
+            onClose={() => setEmojiDialogOpen(false)}
+            chatType="encrypted"
+            chatId={encryptedDirectChatId}
+            chatName={`Chat with ${currentChat.otherUserDisplayName}`}
+          />
+        )}
       </Box>
     );
   }
 );
 
 export default EncryptedDirectChatDetails;
+

--- a/client/src/lib/api/notifications.ts
+++ b/client/src/lib/api/notifications.ts
@@ -1,4 +1,4 @@
-import agent from "./agent";
+﻿import agent from "./agent";
 import type { NotificationCounters } from "../types";
 
 const notificationsApi = {
@@ -13,6 +13,15 @@ const notificationsApi = {
 
   async markDirectChatRead(directChatId: string): Promise<void> {
     await agent.post(`/notifications/direct-chats/${directChatId}/read`, {});
+  },
+
+  async markEncryptedDirectChatRead(
+    encryptedDirectChatId: string
+  ): Promise<void> {
+    await agent.post(
+      `/notifications/encrypted-direct-chats/${encryptedDirectChatId}/read`,
+      {}
+    );
   },
 };
 

--- a/client/src/lib/crypto/encryptedChat.ts
+++ b/client/src/lib/crypto/encryptedChat.ts
@@ -1,0 +1,144 @@
+const KEY_STORAGE_PREFIX = "encrypted-chat-key:";
+
+function textEncoder() {
+  return new TextEncoder();
+}
+
+function textDecoder() {
+  return new TextDecoder();
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+const AES_GCM_IV_LENGTH = 12;
+
+async function encryptString(key: CryptoKey, plaintext: string) {
+  const encoder = textEncoder();
+  const data = encoder.encode(plaintext);
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_LENGTH));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data
+  );
+  const combined = new Uint8Array(iv.length + encrypted.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(encrypted), iv.length);
+  return arrayBufferToBase64(combined.buffer);
+}
+
+async function decryptString(key: CryptoKey, payload: string) {
+  const combined = new Uint8Array(base64ToArrayBuffer(payload));
+  const iv = combined.slice(0, AES_GCM_IV_LENGTH);
+  const ciphertextBytes = combined.slice(AES_GCM_IV_LENGTH);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ciphertextBytes
+  );
+  return textDecoder().decode(decrypted);
+}
+
+export async function deriveChatKey(
+  passphrase: string,
+  chatId: string
+): Promise<CryptoKey> {
+  const passphraseBytes = textEncoder().encode(passphrase);
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    passphraseBytes,
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+
+  const saltBytes = textEncoder().encode(chatId);
+
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: saltBytes,
+      iterations: 120_000,
+      hash: "SHA-256",
+    },
+    baseKey,
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"]
+  );
+}
+
+export async function exportKeyToStorage(
+  chatId: string,
+  key: CryptoKey
+): Promise<void> {
+  const raw = await crypto.subtle.exportKey("raw", key);
+  const base64 = arrayBufferToBase64(raw);
+  localStorage.setItem(`${KEY_STORAGE_PREFIX}${chatId}`, base64);
+}
+
+export async function loadKeyFromStorage(
+  chatId: string
+): Promise<CryptoKey | null> {
+  const stored = localStorage.getItem(`${KEY_STORAGE_PREFIX}${chatId}`);
+  if (!stored) return null;
+  try {
+    const raw = base64ToArrayBuffer(stored);
+    return crypto.subtle.importKey(
+      "raw",
+      raw,
+      { name: "AES-GCM", length: 256 },
+      true,
+      ["encrypt", "decrypt"]
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function clearStoredKey(chatId: string) {
+  localStorage.removeItem(`${KEY_STORAGE_PREFIX}${chatId}`);
+}
+
+export async function encryptMessagePayload(
+  key: CryptoKey,
+  plaintext: string,
+  metadataPlaintext?: string
+): Promise<{ cipherText: string; metadata?: string }> {
+  const cipherText = await encryptString(key, plaintext);
+  let metadata: string | undefined;
+  if (typeof metadataPlaintext === "string") {
+    metadata = await encryptString(key, metadataPlaintext);
+  }
+  return { cipherText, metadata };
+}
+
+export async function decryptMessagePayload(
+  key: CryptoKey,
+  cipherText: string
+): Promise<string> {
+  return decryptString(key, cipherText);
+}
+
+export async function decryptMessageMetadata(
+  key: CryptoKey,
+  cipherTextMetadata: string
+): Promise<string> {
+  return decryptString(key, cipherTextMetadata);
+}

--- a/client/src/lib/hooks/useEncryptedDirectChats.ts
+++ b/client/src/lib/hooks/useEncryptedDirectChats.ts
@@ -1,0 +1,32 @@
+﻿import { useQuery } from "@tanstack/react-query";
+import agent from "../api/agent";
+import type { EncryptedDirectChat } from "../types";
+
+export const useEncryptedDirectChats = () => {
+  const {
+    data: encryptedDirectChats,
+    isLoading: isLoadingEncryptedChats,
+    error,
+  } = useQuery({
+    queryKey: ["encrypted-direct-chats"],
+    queryFn: async () => {
+      try {
+        const response = await agent.get<EncryptedDirectChat[]>(
+          "/encryptedDirectChats"
+        );
+        return response.data;
+      } catch (error) {
+        console.error("Error fetching encrypted direct chats:", error);
+        throw error;
+      }
+    },
+    retry: 3,
+    retryDelay: 1000,
+  });
+
+  return {
+    encryptedDirectChats: encryptedDirectChats || [],
+    isLoadingEncryptedChats,
+    error,
+  };
+};

--- a/client/src/lib/hooks/useEncryptedDirectMessages.ts
+++ b/client/src/lib/hooks/useEncryptedDirectMessages.ts
@@ -1,0 +1,294 @@
+﻿import { useLocalObservable } from "mobx-react-lite";
+import {
+  HubConnection,
+  HubConnectionBuilder,
+  HubConnectionState,
+} from "@microsoft/signalr";
+import { useEffect, useRef } from "react";
+import type {
+  EncryptedDirectMessage,
+  MessageReaction,
+  PagedList,
+} from "../types";
+import { runInAction } from "mobx";
+import { toast } from "react-toastify";
+import { calculatePageSizeForMessages } from "../util/util";
+import notificationsApi from "../api/notifications";
+import { useStore } from "./useStore";
+import { useAccount } from "./useAccount";
+
+export const useEncryptedDirectMessages = (encryptedDirectChatId?: string) => {
+  const { messagesNotificationsStore } = useStore();
+  const { currentUser } = useAccount();
+  const currentUserIdRef = useRef<string | undefined>(undefined);
+  currentUserIdRef.current = currentUser?.id;
+
+  const encryptedDirectMessageStore = useLocalObservable(() => ({
+    messages: [] as EncryptedDirectMessage[],
+    hubConnection: null as HubConnection | null,
+    hasOlderMessages: false,
+    isLoadingOlder: false,
+    oldestMessageCursor: null as Date | null,
+    currentChatId: null as string | null,
+
+    async createHubConnection(encryptedDirectChatId: string) {
+      if (!encryptedDirectChatId) return;
+
+      if (
+        this.hubConnection &&
+        this.currentChatId === encryptedDirectChatId &&
+        this.hubConnection.state !== HubConnectionState.Disconnected
+      ) {
+        return;
+      }
+
+      if (this.hubConnection) {
+        await this.hubConnection.stop().catch(() => {});
+        this.hubConnection = null;
+      }
+
+      const initialPageSize = calculatePageSizeForMessages();
+
+      this.hubConnection = new HubConnectionBuilder()
+        .withUrl(
+          `${
+            import.meta.env.VITE_CHATROOM_ENCRYPTED_DIRECT_MESSAGES_URL ||
+            "https://localhost:5001/encrypted-direct-messages"
+          }?encryptedDirectChatId=${encryptedDirectChatId}&initialPageSize=${initialPageSize}`,
+          {
+            withCredentials: true,
+          }
+        )
+        .withAutomaticReconnect()
+        .build();
+
+      this.currentChatId = encryptedDirectChatId;
+
+      this.hubConnection.start().catch((error) => {
+        const isNegotiationAbort =
+          error instanceof Error &&
+          typeof error.message === "string" &&
+          error.message.includes("stopped during negotiation");
+
+        if (!isNegotiationAbort && import.meta.env.DEV) {
+          console.log(
+            "Error establishing encrypted direct message connection: ",
+            error
+          );
+        }
+
+        if (!isNegotiationAbort) {
+          this.hubConnection?.stop().catch(() => {});
+          this.hubConnection = null;
+          this.currentChatId = null;
+        }
+      });
+
+      this.hubConnection.on(
+        "LoadEncryptedDirectMessages",
+        (pagedResult: PagedList<EncryptedDirectMessage, Date>) => {
+          runInAction(() => {
+            const existingIds = new Set(this.messages.map((m) => m.id));
+            const merged = pagedResult.items.filter(
+              (m) => !existingIds.has(m.id)
+            );
+            if (this.messages.length === 0) {
+              this.messages = pagedResult.items;
+            } else if (merged.length > 0) {
+              this.messages.push(...merged);
+            }
+            this.hasOlderMessages = !!pagedResult.nextCursor;
+            if (pagedResult.nextCursor) {
+              this.oldestMessageCursor = pagedResult.nextCursor;
+            }
+          });
+        }
+      );
+
+      this.hubConnection.on(
+        "ReceiveOlderEncryptedMessages",
+        (pagedResult: PagedList<EncryptedDirectMessage, Date>) => {
+          runInAction(() => {
+            const existingIds = new Set(this.messages.map((m) => m.id));
+            const merged = pagedResult.items.filter(
+              (m) => !existingIds.has(m.id)
+            );
+            this.messages = [...merged, ...this.messages];
+            this.hasOlderMessages = !!pagedResult.nextCursor;
+            this.oldestMessageCursor = pagedResult.nextCursor;
+            this.isLoadingOlder = false;
+          });
+        }
+      );
+
+      this.hubConnection.on(
+        "ReceiveEncryptedDirectMessage",
+        (message: EncryptedDirectMessage) => {
+          runInAction(() => {
+            const existingIndex = this.messages.findIndex(
+              (m) => m.id === message.id
+            );
+            if (existingIndex === -1) {
+              this.messages.push(message);
+            } else {
+              this.messages[existingIndex] = message;
+            }
+          });
+
+          const cleared =
+            messagesNotificationsStore.markEncryptedDirectChatRead(
+              encryptedDirectChatId
+            );
+          if (cleared) {
+            notificationsApi
+              .markEncryptedDirectChatRead(encryptedDirectChatId)
+              .catch(() => {});
+          }
+        }
+      );
+
+      this.hubConnection.on(
+        "ReceiveEncryptedReactionUpdate",
+        (update: {
+          action: "added" | "removed";
+          chatRoomId: string;
+          messageId: string;
+          emoji: string;
+          userId: string;
+          displayName: string;
+          createdAt?: string | Date;
+        }) => {
+          runInAction(() => {
+            const idx = this.messages.findIndex(
+              (m) => m.id === update.messageId
+            );
+            if (idx === -1) return;
+            const msg = this.messages[idx] as EncryptedDirectMessage & {
+              reactions?: MessageReaction[];
+            };
+            const list = msg.reactions ? [...msg.reactions] : [];
+            if (update.action === "added") {
+              if (
+                !list.some(
+                  (r) => r.userId === update.userId && r.emoji === update.emoji
+                )
+              ) {
+                list.push({
+                  messageId: update.messageId,
+                  emoji: update.emoji,
+                  userId: update.userId,
+                  displayName: update.displayName,
+                  createdAt: update.createdAt
+                    ? new Date(update.createdAt)
+                    : new Date(),
+                });
+              }
+            } else {
+              const i = list.findIndex(
+                (r) => r.userId === update.userId && r.emoji === update.emoji
+              );
+              if (i !== -1) list.splice(i, 1);
+            }
+            this.messages[idx] = {
+              ...(msg as EncryptedDirectMessage),
+              reactions: list,
+            };
+          });
+        }
+      );
+
+      this.hubConnection.on(
+        "ReceiveError",
+        (errorCode: number, message: string) => {
+          runInAction(() => {
+            this.isLoadingOlder = false;
+          });
+          if (import.meta.env.DEV) console.log(errorCode, message);
+          toast.error(message);
+        }
+      );
+    },
+
+    loadOlderMessages() {
+      if (!this.hubConnection || !this.hasOlderMessages || this.isLoadingOlder)
+        return;
+
+      runInAction(() => {
+        this.isLoadingOlder = true;
+      });
+
+      const pageSize = Math.max(
+        10,
+        Math.floor(calculatePageSizeForMessages() / 2)
+      );
+
+      this.hubConnection
+        .invoke(
+          "LoadMoreEncryptedMessages",
+          encryptedDirectChatId,
+          this.oldestMessageCursor,
+          pageSize
+        )
+        .catch((error) => {
+          runInAction(() => {
+            this.isLoadingOlder = false;
+          });
+          if (import.meta.env.DEV)
+            console.log("Error loading older messages: ", error);
+          toast.error("Failed to load older messages");
+        });
+    },
+
+    async stopHubConnection() {
+      if (this.hubConnection) {
+        const connection = this.hubConnection;
+        this.hubConnection = null;
+        await connection.stop().catch(() => {});
+      }
+      this.currentChatId = null;
+    },
+
+    reset() {
+      this.messages = [];
+      this.hasOlderMessages = false;
+      this.isLoadingOlder = false;
+      this.oldestMessageCursor = null;
+    },
+  }));
+
+  useEffect(() => {
+    if (!encryptedDirectChatId) {
+      encryptedDirectMessageStore.stopHubConnection();
+      encryptedDirectMessageStore.reset();
+      return;
+    }
+
+    encryptedDirectMessageStore
+      .createHubConnection(encryptedDirectChatId)
+      .catch(() => {});
+  }, [encryptedDirectChatId, encryptedDirectMessageStore]);
+
+  useEffect(() => {
+    if (!encryptedDirectChatId) {
+      messagesNotificationsStore.setActiveEncryptedDirectChat(null);
+      return;
+    }
+
+    const shouldSync = messagesNotificationsStore.setActiveEncryptedDirectChat(
+      encryptedDirectChatId
+    );
+    if (shouldSync) {
+      notificationsApi
+        .markEncryptedDirectChatRead(encryptedDirectChatId)
+        .catch(() => {});
+    }
+
+    return () => {
+      messagesNotificationsStore.setActiveEncryptedDirectChat(null);
+    };
+  }, [encryptedDirectChatId, messagesNotificationsStore]);
+
+  return {
+    encryptedDirectMessageStore,
+  };
+};

--- a/client/src/lib/hooks/useEncryptedMessagesHub.ts
+++ b/client/src/lib/hooks/useEncryptedMessagesHub.ts
@@ -1,0 +1,86 @@
+﻿import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  startEncryptedMessagesHub,
+  onEncrypted,
+  offEncrypted,
+  encryptedConnection,
+} from "../realtime/encryptedMessagesHub";
+import { useStore } from "./useStore";
+import { useAccount } from "./useAccount";
+import type { EncryptedDirectMessage } from "../types";
+
+type EncryptedDirectChatUpdatedPayload = {
+  encryptedDirectChatId?: string;
+  message?: EncryptedDirectMessage;
+};
+
+type RegisteredHandler = {
+  event: string;
+  handler: (...args: unknown[]) => void;
+};
+
+export function useEncryptedMessagesHub() {
+  const queryClient = useQueryClient();
+  const handlersRef = useRef<RegisteredHandler[]>([]);
+  const { messagesNotificationsStore } = useStore();
+  const { currentUser } = useAccount();
+  const currentUserIdRef = useRef<string | undefined>(undefined);
+  currentUserIdRef.current = currentUser?.id;
+
+  useEffect(() => {
+    let mounted = true;
+
+    const attachHandler = async () => {
+      try {
+        await startEncryptedMessagesHub();
+        if (!mounted) return;
+
+        handlersRef.current.forEach(({ event, handler }) =>
+          offEncrypted(event, handler)
+        );
+        handlersRef.current = [];
+
+        const encryptedChatHandler = (...args: unknown[]) => {
+          const payload = args[0] as
+            | EncryptedDirectChatUpdatedPayload
+            | undefined;
+          queryClient.invalidateQueries({
+            queryKey: ["encrypted-direct-chats"],
+            exact: false,
+          });
+
+          const chatId = payload?.encryptedDirectChatId;
+          const message = payload?.message;
+          const currentUserId = currentUserIdRef.current;
+
+          if (!chatId || !message) return;
+          if (currentUserId && message.senderId === currentUserId) return;
+
+          messagesNotificationsStore.incrementEncryptedDirectUnread(chatId);
+        };
+
+        onEncrypted("EncryptedDirectChatUpdated", encryptedChatHandler);
+        handlersRef.current.push({
+          event: "EncryptedDirectChatUpdated",
+          handler: encryptedChatHandler,
+        });
+      } catch (err) {
+        if (import.meta.env.DEV)
+          console.error("Encrypted messages hub connect error", err);
+      }
+    };
+
+    attachHandler();
+
+    return () => {
+      mounted = false;
+      handlersRef.current.forEach(({ event, handler }) =>
+        offEncrypted(event, handler)
+      );
+      handlersRef.current = [];
+    };
+  }, [queryClient, messagesNotificationsStore]);
+
+  return { connection: encryptedConnection() };
+}

--- a/client/src/lib/hooks/useFriendsRealtime.ts
+++ b/client/src/lib/hooks/useFriendsRealtime.ts
@@ -76,6 +76,7 @@ export const useFriendsRealtime = () => {
           );
 
           queryClient.invalidateQueries({ queryKey: ["direct-chats"] });
+          queryClient.invalidateQueries({ queryKey: ["encrypted-direct-chats"] });
 
           toast.success(
             `${newFriend.displayName} accepted your friend request!`
@@ -146,6 +147,7 @@ export const useFriendsRealtime = () => {
         });
 
         queryClient.invalidateQueries({ queryKey: ["direct-chats"] });
+        queryClient.invalidateQueries({ queryKey: ["encrypted-direct-chats"] });
       });
 
       this.hubConnection.on("FriendRemoved", (removedByUserId: string) => {
@@ -166,6 +168,7 @@ export const useFriendsRealtime = () => {
         });
 
         queryClient.invalidateQueries({ queryKey: ["direct-chats"] });
+        queryClient.invalidateQueries({ queryKey: ["encrypted-direct-chats"] });
       });
     },
 

--- a/client/src/lib/realtime/encryptedMessagesHub.ts
+++ b/client/src/lib/realtime/encryptedMessagesHub.ts
@@ -1,0 +1,67 @@
+﻿import {
+  HubConnection,
+  HubConnectionBuilder,
+  HubConnectionState,
+} from "@microsoft/signalr";
+
+let hubConnection: HubConnection | null = null;
+let startPromise: Promise<void> | null = null;
+
+export function getEncryptedMessagesHub(): HubConnection | null {
+  return hubConnection;
+}
+
+export async function startEncryptedMessagesHub(): Promise<HubConnection> {
+  const url =
+    (import.meta.env.VITE_CHATROOM_ENCRYPTED_MESSAGES_URL as string) ||
+    "https://localhost:5001/encrypted-messages";
+
+  if (hubConnection) {
+    if (hubConnection.state === HubConnectionState.Connected)
+      return hubConnection;
+    if (startPromise) {
+      await startPromise;
+      return hubConnection;
+    }
+    startPromise = hubConnection.start().finally(() => {
+      startPromise = null;
+    });
+    await startPromise;
+    return hubConnection;
+  }
+
+  hubConnection = new HubConnectionBuilder()
+    .withUrl(url, { withCredentials: true })
+    .withAutomaticReconnect()
+    .build();
+
+  startPromise = hubConnection.start().finally(() => {
+    startPromise = null;
+  });
+  await startPromise;
+  return hubConnection;
+}
+
+export async function stopEncryptedMessagesHub() {
+  if (hubConnection?.state === HubConnectionState.Connected) {
+    await hubConnection.stop();
+  }
+}
+
+export function onEncrypted<TPayload = unknown>(
+  event: string,
+  cb: (payload: TPayload) => void
+) {
+  if (!hubConnection) return;
+  hubConnection.on(event, cb as unknown as (...args: unknown[]) => void);
+}
+
+export function offEncrypted(event: string, cb?: (...args: unknown[]) => void) {
+  if (!hubConnection) return;
+  if (cb) hubConnection.off(event, cb);
+  else hubConnection.off(event);
+}
+
+export function encryptedConnection(): HubConnection | null {
+  return hubConnection;
+}

--- a/client/src/lib/stores/messagesNotificationStore.ts
+++ b/client/src/lib/stores/messagesNotificationStore.ts
@@ -1,11 +1,13 @@
-import { makeAutoObservable, observable } from "mobx";
+﻿import { makeAutoObservable, observable } from "mobx";
 import type { NotificationCounters } from "../types";
 
 export class MessagesNotificationStore {
   unreadByRoom = observable.map<string, number>();
   directUnreadByChat = observable.map<string, number>();
+  encryptedDirectUnreadByChat = observable.map<string, number>();
   activeChatRoomId: string | null = null;
   activeDirectChatId: string | null = null;
+  activeEncryptedDirectChatId: string | null = null;
   windowFocused = true;
   private audioContext: AudioContext | null = null;
 
@@ -20,6 +22,7 @@ export class MessagesNotificationStore {
   hydrate(counters: NotificationCounters) {
     this.unreadByRoom.clear();
     this.directUnreadByChat.clear();
+    this.encryptedDirectUnreadByChat.clear();
 
     Object.entries(counters.chatRooms).forEach(([chatRoomId, count]) => {
       if (count > 0) this.unreadByRoom.set(chatRoomId, count);
@@ -28,6 +31,12 @@ export class MessagesNotificationStore {
     Object.entries(counters.directChats).forEach(([chatId, count]) => {
       if (count > 0) this.directUnreadByChat.set(chatId, count);
     });
+
+    Object.entries(counters.encryptedDirectChats ?? {}).forEach(
+      ([chatId, count]) => {
+        if (count > 0) this.encryptedDirectUnreadByChat.set(chatId, count);
+      }
+    );
   }
 
   setActiveChatRoom(chatRoomId: string | null): boolean {
@@ -48,6 +57,15 @@ export class MessagesNotificationStore {
     return true;
   }
 
+  setActiveEncryptedDirectChat(chatId: string | null): boolean {
+    this.activeEncryptedDirectChatId = chatId;
+    if (!chatId || !this.windowFocused) return false;
+    const unread = this.encryptedDirectUnreadByChat.get(chatId) ?? 0;
+    if (unread === 0) return false;
+    this.encryptedDirectUnreadByChat.delete(chatId);
+    return true;
+  }
+
   setWindowFocused(focused: boolean) {
     this.windowFocused = focused;
     if (!focused) return;
@@ -58,6 +76,10 @@ export class MessagesNotificationStore {
 
     if (this.activeDirectChatId) {
       this.directUnreadByChat.delete(this.activeDirectChatId);
+    }
+
+    if (this.activeEncryptedDirectChatId) {
+      this.encryptedDirectUnreadByChat.delete(this.activeEncryptedDirectChatId);
     }
   }
 
@@ -79,6 +101,16 @@ export class MessagesNotificationStore {
     this.playNotificationSound();
   }
 
+  incrementEncryptedDirectUnread(chatId: string) {
+    if (!chatId) return;
+    if (this.activeEncryptedDirectChatId === chatId && this.windowFocused)
+      return;
+
+    const current = this.encryptedDirectUnreadByChat.get(chatId) ?? 0;
+    this.encryptedDirectUnreadByChat.set(chatId, current + 1);
+    this.playNotificationSound();
+  }
+
   markRoomRead(chatRoomId: string): boolean {
     if (!this.unreadByRoom.has(chatRoomId)) return false;
     this.unreadByRoom.delete(chatRoomId);
@@ -91,9 +123,16 @@ export class MessagesNotificationStore {
     return true;
   }
 
+  markEncryptedDirectChatRead(chatId: string): boolean {
+    if (!this.encryptedDirectUnreadByChat.has(chatId)) return false;
+    this.encryptedDirectUnreadByChat.delete(chatId);
+    return true;
+  }
+
   clearAll() {
     this.unreadByRoom.clear();
     this.directUnreadByChat.clear();
+    this.encryptedDirectUnreadByChat.clear();
   }
 
   get totalChatRoomUnread() {
@@ -112,8 +151,20 @@ export class MessagesNotificationStore {
     return total;
   }
 
+  get totalEncryptedDirectUnread() {
+    let total = 0;
+    for (const count of this.encryptedDirectUnreadByChat.values()) {
+      total += count;
+    }
+    return total;
+  }
+
   get totalUnread() {
-    return this.totalChatRoomUnread + this.totalDirectUnread;
+    return (
+      this.totalChatRoomUnread +
+      this.totalDirectUnread +
+      this.totalEncryptedDirectUnread
+    );
   }
 
   private async playNotificationSound() {

--- a/client/src/lib/types/index.d.ts
+++ b/client/src/lib/types/index.d.ts
@@ -1,4 +1,4 @@
-export type PagedList<T, TCursor> = {
+﻿export type PagedList<T, TCursor> = {
   items: T[];
   nextCursor: TCursor;
 };
@@ -216,6 +216,39 @@ export type DirectMessage = {
   replyToMediaOriginalFileName?: string;
   reactions?: MessageReaction[];
 };
+export type EncryptedDirectChat = {
+  id: string;
+  otherUserId: string;
+  otherUserDisplayName: string;
+  otherUserSlug: string;
+  otherUserImageUrl?: string;
+  lastActivityAt: Date;
+  lastMessageSenderId?: string;
+  isOnline: boolean;
+  lastSeen?: Date;
+  status: string;
+};
+
+export type EncryptedDirectMessage = {
+  id: string;
+  cipherText: string;
+  cipherTextMetadata?: string;
+  version: string;
+  createdAt: Date;
+  senderId: string;
+  senderDisplayName: string;
+  senderSlug: string;
+  senderImageUrl?: string;
+  isOwnMessage: boolean;
+  type: MessageType;
+  replyToMessageId?: string;
+  replyToCipherText?: string;
+  replyToCipherTextMetadata?: string;
+  replyToVersion?: string;
+  replyToSenderId?: string;
+  replyToSenderDisplayName?: string;
+  reactions?: MessageReaction[];
+};
 
 export type MessageReaction = {
   messageId: string;
@@ -287,4 +320,5 @@ export type OnlineUsersDto = {
 export type NotificationCounters = {
   chatRooms: Record<string, number>;
   directChats: Record<string, number>;
+  encryptedDirectChats: Record<string, number>;
 };


### PR DESCRIPTION
Closes #104 
This pull request introduces encrypted direct chat and messaging functionality, along with related notification and access control improvements. The main changes include new controllers and SignalR hubs for encrypted direct chats, expanded notification services, updates to access checks for media and emoji preferences, and new mapping profiles for encrypted chat entities.

**Encrypted Direct Chat & Messaging Functionality**
* Added `EncryptedDirectChatsController` to handle encrypted direct chat creation, message retrieval, and sending messages.
* Implemented `EncryptedDirectMessageHub` and `EncryptedMessageHub` SignalR hubs to support real-time encrypted messaging and notifications. [[1]](diffhunk://#diff-b3616e3ee1fa436ad6748db1bab0dcefcbc4c51600526030b6b1cc4316719197R1-R115) [[2]](diffhunk://#diff-99944ceffec0ce29ecb193be2b6a7b05c4f3c8105b2482d86397164bc9f1afdeR1-R16)
* Added `CreateEncryptedDirectChat` command to create encrypted chats only between friends, preventing self-chats and duplicates.

**Notification Services & SignalR Integration**
* Introduced `EncryptedDirectMessagesNotificationService` for notifying users about new encrypted messages and updating unread counts.
* Registered new notification service and SignalR hubs for encrypted messaging in `Program.cs`. [[1]](diffhunk://#diff-7b906291841db2ef7c04a92d22f24fe4e08c3c1205feff9d0fefcf5a61aac513R95) [[2]](diffhunk://#diff-7b906291841db2ef7c04a92d22f24fe4e08c3c1205feff9d0fefcf5a61aac513R162-R163)
* Added endpoint in `NotificationsController` to mark encrypted direct chat notifications as read.

**Access Control & Media Handling**
* Updated media access checks to allow users in encrypted direct chats to access associated media files.
* Modified emoji preference logic and validation to support "EncryptedDirectChat" type, including access checks and removal of restrictive validation. [[1]](diffhunk://#diff-7b64c9d977b3fa41db1a24d9e39481a9adb64b708fd5df4272e8cbe554398363L27-L31) [[2]](diffhunk://#diff-7b64c9d977b3fa41db1a24d9e39481a9adb64b708fd5df4272e8cbe554398363R53-R63) [[3]](diffhunk://#diff-5bdc2729a1d47d8aa971625a237ba0efda39e6bdef0bf744645cbf3c7d286290L10-L14)

**Mapping Profiles**
* Added mapping profiles for `EncryptedDirectChat`, `EncryptedDirectMessage`, and `EncryptedDirectMessageReaction` to support DTO conversion and enrich API responses.

These changes collectively enable secure, encrypted direct messaging between users, ensure proper notification delivery, and extend related functionality such as media access and emoji preferences to encrypted chats.