### PR TITLE
Profile page and card should show user tag #2137

### DIFF
--- a/Application/Core/MappingProfiles.cs
+++ b/Application/Core/MappingProfiles.cs
@@ -38,6 +38,8 @@ public class MappingProfiles : Profile
             .ForMember(d => d.DisplayName, o => o.MapFrom(s => s.User.DisplayName))
             .ForMember(d => d.Bio, o => o.MapFrom(s => s.User.Bio))
             .ForMember(d => d.Id, o => o.MapFrom(s => s.User.Id))
+            .ForMember(d => d.Slug, o => o.MapFrom(s => s.User.Slug))
+            .ForMember(d => d.Tag, o => o.MapFrom(s => s.User.Tag))
             .ForMember(d => d.ImageUrl, o => o.MapFrom(s => s.User.ImageUrl))
             .ForMember(d => d.BannerUrl, o => o.MapFrom(s => s.User.BannerUrl))
             .ForMember(
@@ -56,6 +58,7 @@ public class MappingProfiles : Profile
             .ForMember(d => d.Status, o => o.MapFrom(s => s.User.Status.ToString()));
 
         CreateMap<User, UserProfileDto>()
+            .ForMember(d => d.Tag, o => o.MapFrom(s => s.Tag))
             .ForMember(
                 d => d.FriendsCount,
                 o => o.MapFrom(s => s.Friends.Count)

--- a/Application/Profiles/DTOs/UserProfileDto.cs
+++ b/Application/Profiles/DTOs/UserProfileDto.cs
@@ -5,6 +5,7 @@ public class UserProfileDto
     public required string Id { get; set; }
     public required string DisplayName { get; set; }
     public required string Slug { get; set; }
+    public int Tag { get; set; }
     public string? Bio { get; set; }
     public string? ImageUrl { get; set; }
     public string? BannerUrl { get; set; }

--- a/client/src/app/shared/components/ProfileCard.tsx
+++ b/client/src/app/shared/components/ProfileCard.tsx
@@ -1,12 +1,15 @@
 import { Link } from "react-router";
 import { Avatar, Box, Typography } from "@mui/material";
 import type { Profile } from "../../../lib/types";
+import { formatUserTag } from "../../../lib/util/util";
 
 type Props = {
   profile: Profile;
 };
 
 export default function ProfileCard({ profile }: Props) {
+  const formattedTag = formatUserTag(profile.tag);
+
   return (
     <Link to={`/profiles/${profile.slug}`} style={{ textDecoration: "none" }}>
       <Box
@@ -44,16 +47,27 @@ export default function ProfileCard({ profile }: Props) {
             <Typography variant="h5" fontWeight="bold" color="white">
               {profile.displayName}
             </Typography>
+            {formattedTag && (
+              <Typography
+                variant="subtitle2"
+                color="white"
+                sx={{ opacity: 0.9 }}
+              >
+                #{formattedTag}
+              </Typography>
+            )}
             {profile.bio && (
               <Typography
                 variant="body2"
                 color="white"
-                noWrap
                 sx={{
-                  maxWidth: 200,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
+                  mt: 0.75,
+                  maxWidth: 220,
                   opacity: 0.85,
+                  display: "-webkit-box",
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
                 }}
               >
                 {profile.bio}

--- a/client/src/app/shared/components/mediaChatComponent/chatMessageList/MessageHeader.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/chatMessageList/MessageHeader.tsx
@@ -1,4 +1,5 @@
 import { Box, Chip, Typography } from "@mui/material";
+import { Link } from "react-router";
 import { timeAgo, formatDate } from "../../../../../lib/util/util";
 
 type Props = {
@@ -6,6 +7,8 @@ type Props = {
   displayName: string;
   createdAt: Date | string;
   messageType?: string;
+  profileSlug?: string;
+  showUserProfiles?: boolean;
 };
 
 export default function MessageHeader({
@@ -13,7 +16,14 @@ export default function MessageHeader({
   displayName,
   createdAt,
   messageType,
+  profileSlug,
+  showUserProfiles = true,
 }: Props) {
+  const linkEnabled = showUserProfiles && !!profileSlug;
+  const linkProps = linkEnabled
+    ? ({ component: Link, to: `/profiles/${profileSlug}` } as const)
+    : {};
+
   return (
     <Box
       display="flex"
@@ -23,7 +33,13 @@ export default function MessageHeader({
     >
       <Typography
         variant="subtitle1"
-        sx={{ fontWeight: "bold", textDecoration: "none" }}
+        sx={{
+          fontWeight: "bold",
+          textDecoration: "none",
+          color: "inherit",
+          "&:hover": linkEnabled ? { textDecoration: "underline" } : undefined,
+        }}
+        {...linkProps}
       >
         {displayName}
       </Typography>

--- a/client/src/app/shared/components/mediaChatComponent/chatMessageList/SingleMessageRow.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/chatMessageList/SingleMessageRow.tsx
@@ -42,6 +42,8 @@ export default function SingleMessageRow({
   const displayName =
     message.senderDisplayName || message.displayName || "Unknown";
 
+  const profileSlug = message.senderSlug || message.userSlug;
+
   return (
     <Box
       id={`msg-${message.id}`}
@@ -63,6 +65,7 @@ export default function SingleMessageRow({
       {!continuation ? (
         <MessageAvatar
           userId={message.senderId || message.userId || ""}
+          userSlug={profileSlug}
           imageUrl={message.senderImageUrl || message.imageUrl}
           displayName={displayName}
           showUserProfiles={showUserProfiles}
@@ -82,6 +85,8 @@ export default function SingleMessageRow({
             displayName={displayName}
             createdAt={message.createdAt}
             messageType={message.type}
+            profileSlug={profileSlug}
+            showUserProfiles={showUserProfiles}
           />
         )}
 

--- a/client/src/features/chatRooms/details/ChatRoomMemberDialog.tsx
+++ b/client/src/features/chatRooms/details/ChatRoomMemberDialog.tsx
@@ -10,7 +10,9 @@ import {
   Typography,
 } from "@mui/material";
 import { useEffect, useState } from "react";
+import { Link } from "react-router";
 import type { ChatRoomRole, Profile } from "../../../lib/types";
+import { formatUserTag } from "../../../lib/util/util";
 
 type Props = {
   open: boolean;
@@ -46,6 +48,8 @@ export default function ChatRoomMemberDialog({
     };
   }, [open, member, loadRoles]);
 
+  const formattedTag = member ? formatUserTag(member.tag) : undefined;
+
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Member details</DialogTitle>
@@ -66,25 +70,54 @@ export default function ChatRoomMemberDialog({
 
             {/* Avatar and name overlay */}
             <Box sx={{ px: 2, pb: 2, position: "relative" }}>
-              <Avatar
-                src={member.imageUrl || "/images/user.png"}
-                alt={member.displayName}
-                sx={{
-                  width: 90,
-                  height: 90,
-                  border: "4px solid",
-                  borderColor: "background.paper",
-                  position: "relative",
-                  top: -45,
-                }}
-              />
+              <Link
+                to={`/profiles/${member.slug}`}
+                style={{ textDecoration: "none" }}
+              >
+                <Avatar
+                  src={member.imageUrl || "/images/user.png"}
+                  alt={member.displayName}
+                  sx={{
+                    width: 90,
+                    height: 90,
+                    border: "4px solid",
+                    borderColor: "background.paper",
+                    position: "relative",
+                    top: -45,
+                  }}
+                />
+              </Link>
               <Box sx={{ mt: -3 }}>
-                <Typography variant="h6" fontWeight={700}>
+                <Typography
+                  variant="h6"
+                  fontWeight={700}
+                  component={Link}
+                  to={`/profiles/${member.slug}`}
+                  sx={{
+                    color: "text.primary",
+                    textDecoration: "none",
+                    "&:hover": { textDecoration: "underline" },
+                  }}
+                >
                   {member.displayName}
                 </Typography>
+                {formattedTag && (
+                  <Typography variant="body2" color="text.secondary">
+                    #{formattedTag}
+                  </Typography>
+                )}
                 <Typography variant="body2" color="text.secondary">
                   {member.status || (member.isOnline ? "Online" : "Offline")}
                 </Typography>
+                {member.bio && (
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 1.5 }}
+                  >
+                    {member.bio}
+                  </Typography>
+                )}
               </Box>
             </Box>
 

--- a/client/src/features/chatRooms/details/ChatRoomMemberPopover.tsx
+++ b/client/src/features/chatRooms/details/ChatRoomMemberPopover.tsx
@@ -1,7 +1,9 @@
 import Popover from "@mui/material/Popover";
 import { Avatar, Box, Chip, Divider, Stack, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
+import { Link } from "react-router";
 import type { ChatRoomRole, Profile } from "../../../lib/types";
+import { formatUserTag } from "../../../lib/util/util";
 
 type Props = {
   open: boolean;
@@ -39,6 +41,8 @@ export default function ChatRoomMemberPopover({
     };
   }, [open, member, loadRoles]);
 
+  const formattedTag = member ? formatUserTag(member.tag) : undefined;
+
   return (
     <Popover
       open={open}
@@ -72,25 +76,74 @@ export default function ChatRoomMemberPopover({
           />
           {/* Avatar + name */}
           <Box sx={{ px: 2, pb: 2, position: "relative" }}>
-            <Avatar
-              src={member.imageUrl || "/images/user.png"}
-              alt={member.displayName}
-              sx={{
-                width: 64,
-                height: 64,
-                border: "3px solid",
-                borderColor: "background.paper",
-                position: "relative",
-                top: -32,
-              }}
-            />
+            <Link
+              to={`/profiles/${member.slug}`}
+              style={{ textDecoration: "none" }}
+            >
+              <Avatar
+                src={member.imageUrl || "/images/user.png"}
+                alt={member.displayName}
+                sx={{
+                  width: 64,
+                  height: 64,
+                  border: "3px solid",
+                  borderColor: "background.paper",
+                  position: "relative",
+                  top: -32,
+                }}
+              />
+            </Link>
             <Box sx={{ mt: -2 }}>
-              <Typography variant="subtitle1" fontWeight={700}>
-                {member.displayName}
-              </Typography>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  flexDirection: "row",
+                }}
+              >
+                <Typography
+                  variant="subtitle1"
+                  fontWeight={700}
+                  component={Link}
+                  to={`/profiles/${member.slug}`}
+                  sx={{
+                    color: "text.primary",
+                    textDecoration: "none",
+                    "&:hover": { textDecoration: "underline" },
+                    lineHeight: 1.2,
+                    display: "flex",
+                    alignItems: "center",
+                  }}
+                >
+                  {member.displayName}
+                </Typography>
+                {formattedTag && (
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      lineHeight: 1.2,
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    #{formattedTag}
+                  </Typography>
+                )}
+              </Box>
               <Typography variant="caption" color="text.secondary">
                 {member.status || (member.isOnline ? "Online" : "Offline")}
               </Typography>
+              {member.bio && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 1.5 }}
+                >
+                  {member.bio}
+                </Typography>
+              )}
             </Box>
           </Box>
 

--- a/client/src/features/chatRooms/details/ChatRoomMembersBar.tsx
+++ b/client/src/features/chatRooms/details/ChatRoomMembersBar.tsx
@@ -1,4 +1,5 @@
 import { Avatar, Box, Tooltip, Typography, Button } from "@mui/material";
+import { Link } from "react-router";
 import type { Profile } from "../../../lib/types";
 import { useState } from "react";
 import ChatRoomManageRolesForm from "../forms/ChatRoomManageRolesForm";
@@ -41,13 +42,29 @@ const ChatRoomMembersBar = observer(
                   sx={{ textAlign: "center", minWidth: 120 }}
                 >
                   <Tooltip title={member.displayName}>
-                    <Avatar
-                      src={member.imageUrl}
-                      alt={member.displayName}
-                      sx={{ mb: 1, mx: "auto" }}
-                    />
+                    <Link
+                      to={`/profiles/${member.slug}`}
+                      style={{ textDecoration: "none" }}
+                    >
+                      <Avatar
+                        src={member.imageUrl}
+                        alt={member.displayName}
+                        sx={{ mb: 1, mx: "auto" }}
+                      />
+                    </Link>
                   </Tooltip>
-                  <Typography variant="caption" noWrap>
+                  <Typography
+                    variant="caption"
+                    noWrap
+                    component={Link}
+                    to={`/profiles/${member.slug}`}
+                    sx={{
+                      color: "text.primary",
+                      textDecoration: "none",
+                      display: "inline-block",
+                      "&:hover": { textDecoration: "underline" },
+                    }}
+                  >
                     {member.displayName}
                   </Typography>
                   <Box

--- a/client/src/features/directChats/DirectChatDetails.tsx
+++ b/client/src/features/directChats/DirectChatDetails.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useDirectMessages } from "../../lib/hooks/useDirectMessages";
@@ -144,10 +144,22 @@ const DirectChatDetails = observer(function DirectChatDetails() {
                 currentChat.status ||
                 (currentChat.isOnline ? "Online" : "Offline")
               }
+              component={Link}
+              to={`/profiles/${currentChat.otherUserSlug}`}
             >
               {currentChat.otherUserDisplayName[0]}
             </AvatarWithStatus>
-            <Typography variant="h6" fontWeight="bold">
+            <Typography
+              variant="h6"
+              fontWeight="bold"
+              component={Link}
+              to={`/profiles/${currentChat.otherUserSlug}`}
+              sx={{
+                color: "text.primary",
+                textDecoration: "none",
+                "&:hover": { textDecoration: "underline" },
+              }}
+            >
               {currentChat.otherUserDisplayName}
             </Typography>
           </Box>

--- a/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
+++ b/client/src/features/encryptedDirectChats/EncryptedDirectChatDetails.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { observer, useLocalObservable } from "mobx-react-lite";
 import { reaction, runInAction } from "mobx";
@@ -549,11 +549,23 @@ const EncryptedDirectChatDetails = observer(
                     currentChat.status ||
                     (currentChat.isOnline ? "Online" : "Offline")
                   }
+                  component={Link}
+                  to={`/profiles/${currentChat.otherUserSlug}`}
                 >
                   {currentChat.otherUserDisplayName?.charAt(0).toUpperCase()}
                 </AvatarWithStatus>
                 <Box>
-                  <Typography variant="h6" fontWeight="bold">
+                  <Typography
+                    variant="h6"
+                    fontWeight="bold"
+                    component={Link}
+                    to={`/profiles/${currentChat.otherUserSlug}`}
+                    sx={{
+                      color: "text.primary",
+                      textDecoration: "none",
+                      "&:hover": { textDecoration: "underline" },
+                    }}
+                  >
                     {currentChat.otherUserDisplayName}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">

--- a/client/src/features/profile/ProfilePage.tsx
+++ b/client/src/features/profile/ProfilePage.tsx
@@ -32,6 +32,7 @@ import { useNavigate } from "react-router";
 import ProfileEditForm from "./ProfileEditForm";
 import ImageUploadWidget from "./ImageUploadWidget";
 import { toast } from "react-toastify";
+import { formatUserTag } from "../../lib/util/util";
 
 export default function ProfilePage() {
   const { slug } = useParams();
@@ -44,6 +45,8 @@ export default function ProfilePage() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const isCurrentUser = profile?.id === currentUser?.id;
+
+  const formattedTag = formatUserTag(profile?.tag);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -150,16 +153,35 @@ export default function ProfilePage() {
 
           {/* Profile Info */}
           <Box sx={{ color: "white", flex: 1 }}>
-            <Typography
-              variant="h3"
-              gutterBottom
+            <Box
               sx={{
-                fontWeight: "bold",
-                textShadow: "2px 2px 4px rgba(0,0,0,0.7)",
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                flexDirection: "row",
               }}
             >
-              {profile.displayName}
-            </Typography>
+              <Typography
+                variant="h3"
+                gutterBottom
+                sx={{
+                  fontWeight: "bold",
+                  textShadow: "2px 2px 4px rgba(0,0,0,0.7)",
+                }}
+              >
+                {profile.displayName}
+              </Typography>
+              {formattedTag && (
+                <Typography
+                  variant="h5"
+                  sx={{
+                    textShadow: "2px 2px 4px rgba(0,0,0,0.6)",
+                  }}
+                >
+                  #{formattedTag}
+                </Typography>
+              )}
+            </Box>
 
             {profile.friendsCount !== undefined && (
               <Box display="flex" gap={4} mb={2}>

--- a/client/src/lib/types/index.d.ts
+++ b/client/src/lib/types/index.d.ts
@@ -48,9 +48,11 @@ export type BaseMessage = {
   type: MessageType;
   senderId?: string;
   senderDisplayName?: string;
+  senderSlug?: string;
   senderImageUrl?: string;
   displayName?: string;
   userId?: string;
+  userSlug?: string;
   imageUrl?: string;
   mediaUrl?: string;
   mediaPublicId?: string;
@@ -121,6 +123,7 @@ export type MessageType = "Text" | "Image" | "Video" | "Document" | "Audio";
 export type Profile = {
   id: string;
   displayName: string;
+  tag?: number;
   bio?: string;
   imageUrl?: string;
   bannerUrl?: string;

--- a/client/src/lib/util/util.ts
+++ b/client/src/lib/util/util.ts
@@ -9,6 +9,11 @@ export function timeAgo(date: DateArg<Date>) {
   return formatDistanceToNow(date) + " ago";
 }
 
+export function formatUserTag(tag?: number) {
+  if (tag === undefined || tag === null) return undefined;
+  return String(tag).padStart(4, "0");
+}
+
 export const requiredString = (fieldName: string) =>
   z
     .string({ required_error: `${fieldName} is required` })


### PR DESCRIPTION
Closes #111

This pull request adds user tag support and improves profile linking and display across the application. The most significant changes are the addition of the `tag` field to user profiles, updates to mapping and DTOs to support this field, and UI enhancements to show user tags and make profile elements clickable for navigation.

**Backend data model and mapping updates:**

* Added the `tag` field to `UserProfileDto` and updated mapping profiles to include `tag` and `slug` when mapping user data, ensuring the tag is available wherever user profiles are used. [[1]](diffhunk://#diff-11edd0bab6b1a62050aded59ecc38c23febbc9d6ca2d205edf40e0a1042be7b5R8) [[2]](diffhunk://#diff-4a0c03620c89e6ce4686b0f409dacd34fe48527e68a91f2ca40df0114fa39399R41-R42) [[3]](diffhunk://#diff-4a0c03620c89e6ce4686b0f409dacd34fe48527e68a91f2ca40df0114fa39399R61)

**Profile tag display and formatting:**

* Introduced the `formatUserTag` utility and updated all relevant components (`ProfileCard`, chat member dialogs/popovers, and profile pages) to display the formatted tag alongside the display name. [[1]](diffhunk://#diff-7d36b9c4976e31250566b7e9f8131d0c44fe9d11c950ed6e94d6ca9a66ea2a10R4-R12) [[2]](diffhunk://#diff-7d36b9c4976e31250566b7e9f8131d0c44fe9d11c950ed6e94d6ca9a66ea2a10R50-R70) [[3]](diffhunk://#diff-48cfe9febcd0924e5a509c7df45972a7501ad7141c738896f7d052dd62e3cb56R13-R15) [[4]](diffhunk://#diff-48cfe9febcd0924e5a509c7df45972a7501ad7141c738896f7d052dd62e3cb56R51-R52) [[5]](diffhunk://#diff-48cfe9febcd0924e5a509c7df45972a7501ad7141c738896f7d052dd62e3cb56R89-R120) [[6]](diffhunk://#diff-5a3fdb739b7dcf0dc0678eb4e8296178411c1a6c78931e8b03ff7cd8c53042d3R4-R6) [[7]](diffhunk://#diff-5a3fdb739b7dcf0dc0678eb4e8296178411c1a6c78931e8b03ff7cd8c53042d3R44-R45) [[8]](diffhunk://#diff-5a3fdb739b7dcf0dc0678eb4e8296178411c1a6c78931e8b03ff7cd8c53042d3R95-R146) [[9]](diffhunk://#diff-318a1998e47dc8a84e4c7f70511755a62817ba303964a6685a6c014cd3118023R35) [[10]](diffhunk://#diff-318a1998e47dc8a84e4c7f70511755a62817ba303964a6685a6c014cd3118023R49-R50) [[11]](diffhunk://#diff-318a1998e47dc8a84e4c7f70511755a62817ba303964a6685a6c014cd3118023R156-R163)

**Profile navigation and linking enhancements:**

* Made user avatars and display names in profile cards, chat member dialogs/popovers, chat member bars, and direct/encrypted chat details clickable, linking to the user's profile page for easier navigation. [[1]](diffhunk://#diff-48cfe9febcd0924e5a509c7df45972a7501ad7141c738896f7d052dd62e3cb56R73-R76) [[2]](diffhunk://#diff-5a3fdb739b7dcf0dc0678eb4e8296178411c1a6c78931e8b03ff7cd8c53042d3R79-R82) [[3]](diffhunk://#diff-6ec0a1dc4a97d2baee2521cd3cad6ba03fd9c139e8b2b9a5f48115ca7875ce23R45-R67) [[4]](diffhunk://#diff-714ff9f5bb427624243619360c6c96b7169fe4d238d65ab7f3968d0ba08b14b0R147-R162) [[5]](diffhunk://#diff-1983b89ad8c80fcc9de64498856c8748428d9962cf6af551f94d3bbcb5ffa521R552-R568)

**Chat message and member components updates:**

* Passed and used `profileSlug` in chat message components, enabling profile links in message headers and avatars, and ensured consistent display of user tags and bios in member popovers and dialogs. [[1]](diffhunk://#diff-e42b34d277f06a60896959c0f5f718c28183e62264973a5a6ca56e6d494a0d9fR45-R46) [[2]](diffhunk://#diff-e42b34d277f06a60896959c0f5f718c28183e62264973a5a6ca56e6d494a0d9fR68) [[3]](diffhunk://#diff-e42b34d277f06a60896959c0f5f718c28183e62264973a5a6ca56e6d494a0d9fR88-R89)

**UI consistency and accessibility improvements:**

* Refined typography, hover effects, and layout for profile info sections, member lists, and popovers to improve readability and user experience, including multi-line bio display and better alignment for tags and names. [[1]](diffhunk://#diff-7d36b9c4976e31250566b7e9f8131d0c44fe9d11c950ed6e94d6ca9a66ea2a10R50-R70) [[2]](diffhunk://#diff-48cfe9febcd0924e5a509c7df45972a7501ad7141c738896f7d052dd62e3cb56R89-R120) [[3]](diffhunk://#diff-5a3fdb739b7dcf0dc0678eb4e8296178411c1a6c78931e8b03ff7cd8c53042d3R95-R146) [[4]](diffhunk://#diff-6ec0a1dc4a97d2baee2521cd3cad6ba03fd9c139e8b2b9a5f48115ca7875ce23R45-R67) [[5]](diffhunk://#diff-318a1998e47dc8a84e4c7f70511755a62817ba303964a6685a6c014cd3118023R156-R163)