### PR TITLE
Fix screen share voice

### DIFF
--- a/client/electron/main.js
+++ b/client/electron/main.js
@@ -26,7 +26,8 @@ const warnUnsupportedAudio = (key, message) => {
 const buildAudioResponseForSelection = (mode, source) => {
   if (mode === "system") {
     if (PLATFORM === "win32") {
-      return { audio: "loopbackWithMute", enableLocalEcho: false };
+      // Use loopback so system audio capture does not mute the microphone stream.
+      return { audio: "loopback", enableLocalEcho: false };
     }
     if (PLATFORM === "linux") {
       return { audio: "loopback", enableLocalEcho: false };

--- a/client/src/lib/hooks/useVoiceChannel.ts
+++ b/client/src/lib/hooks/useVoiceChannel.ts
@@ -90,6 +90,7 @@ class VoiceManager {
     { camera?: RTCRtpSender; screen?: RTCRtpSender }
   >();
   private screenAudioSenders = new Map<string, RTCRtpSender>();
+  private screenAudioTransceivers = new Map<string, RTCRtpTransceiver>();
   private negotiationStates = new Map<
     string,
     {
@@ -912,6 +913,7 @@ class VoiceManager {
     }
     this.remoteVideoStreams.delete(connectionId);
     this.detachScreenAudioSenderForConnection(connectionId);
+    this.screenAudioTransceivers.delete(connectionId);
     this.videoSenders.delete(connectionId);
     this.applyParticipantMediaState(connectionId, {
       isCameraEnabled: false,
@@ -964,6 +966,7 @@ class VoiceManager {
     this.detachScreenAudioSenders();
     this.videoSenders.clear();
     this.screenAudioSenders.clear();
+    this.screenAudioTransceivers.clear();
 
     this.speakingMonitors.forEach((_, connectionId) => {
       this.stopRemoteSpeakingMonitor(connectionId);
@@ -1199,9 +1202,14 @@ class VoiceManager {
   ) {
     this.peerConnections.forEach((pc, connectionId) => {
       const existingSender = this.screenAudioSenders.get(connectionId);
-      if (existingSender) {
-        this.updateSenderStreams(existingSender, stream);
-        Promise.resolve(existingSender.replaceTrack(track))
+      const transceiver =
+        this.screenAudioTransceivers.get(connectionId) ?? null;
+      const sender = existingSender ?? transceiver?.sender ?? null;
+
+      if (sender) {
+        this.screenAudioSenders.set(connectionId, sender);
+        this.updateSenderStreams(sender, stream);
+        Promise.resolve(sender.replaceTrack(track))
           .then(() => {
             this.renegotiateConnection(connectionId);
           })
@@ -1212,11 +1220,19 @@ class VoiceManager {
                 err
               );
             }
-            this.detachScreenAudioSenderForConnection(connectionId);
             try {
-              const sender = pc.addTrack(track, stream);
-              this.screenAudioSenders.set(connectionId, sender);
-              this.updateSenderStreams(sender, stream);
+              const result = sender.replaceTrack(null);
+              if (result instanceof Promise) {
+                result.catch(() => {});
+              }
+            } catch {
+              // ignore cleanup errors
+            }
+            this.screenAudioSenders.delete(connectionId);
+            try {
+              const fallbackSender = pc.addTrack(track, stream);
+              this.screenAudioSenders.set(connectionId, fallbackSender);
+              this.updateSenderStreams(fallbackSender, stream);
               this.renegotiateConnection(connectionId);
             } catch (fallbackErr) {
               if (import.meta.env.DEV) {
@@ -1231,9 +1247,9 @@ class VoiceManager {
       }
 
       try {
-        const sender = pc.addTrack(track, stream);
-        this.screenAudioSenders.set(connectionId, sender);
-        this.updateSenderStreams(sender, stream);
+        const newSender = pc.addTrack(track, stream);
+        this.screenAudioSenders.set(connectionId, newSender);
+        this.updateSenderStreams(newSender, stream);
         this.renegotiateConnection(connectionId);
       } catch (err) {
         if (import.meta.env.DEV) {
@@ -1437,14 +1453,29 @@ class VoiceManager {
     const sender = this.screenAudioSenders.get(connectionId);
     if (!sender) return;
     const pc = this.peerConnections.get(connectionId);
-    if (pc) {
+    let detached = false;
+    try {
+      this.updateSenderStreams(sender, null);
+      const result = sender.replaceTrack(null);
+      if (result instanceof Promise) {
+        result.catch(() => {});
+      }
+      detached = true;
+    } catch {
+      // fall through to removeTrack
+    }
+    if (!detached && pc) {
       try {
         pc.removeTrack(sender);
+        detached = true;
       } catch (err) {
         if (import.meta.env.DEV) {
           console.warn("Failed to remove screen audio track", err);
         }
       }
+    }
+    if (!detached && import.meta.env.DEV) {
+      console.warn("Unable to detach screen audio sender");
     }
     this.screenAudioSenders.delete(connectionId);
   }
@@ -1896,9 +1927,27 @@ class VoiceManager {
 
     const stream = await this.ensureLocalMicrophoneStream();
 
-    const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+    const pc = new RTCPeerConnection({
+      iceServers: ICE_SERVERS,
+    });
 
     stream?.getAudioTracks().forEach((track) => pc.addTrack(track, stream));
+
+    if (
+      !this.screenAudioTransceivers.has(connectionId) &&
+      typeof pc.addTransceiver === "function"
+    ) {
+      try {
+        const transceiver = pc.addTransceiver("audio", {
+          direction: "sendrecv",
+        });
+        this.screenAudioTransceivers.set(connectionId, transceiver);
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn("Failed to prepare screen audio transceiver", err);
+        }
+      }
+    }
 
     const addVideoTrack = (
       mediaStream: MediaStream | null,
@@ -1969,14 +2018,18 @@ class VoiceManager {
             if (import.meta.env.DEV) {
               console.warn("Failed to attach remote audio track", err);
             }
-            if (!hadExistingStream && aggregateStream.getAudioTracks().length === 0) {
+            if (
+              !hadExistingStream &&
+              aggregateStream.getAudioTracks().length === 0
+            ) {
               this.remoteAudioStreams.delete(connectionId);
             }
             return;
           }
 
           let handleRemovetrack:
-            ((removeEvent: MediaStreamTrackEvent) => void) | null = null;
+            | ((removeEvent: MediaStreamTrackEvent) => void)
+            | null = null;
 
           const handleTrackRemoval = () => {
             audioTrack.removeEventListener("ended", handleTrackRemoval);

--- a/client/src/lib/hooks/useVoiceChannel.ts
+++ b/client/src/lib/hooks/useVoiceChannel.ts
@@ -1951,8 +1951,74 @@ class VoiceManager {
       const [trackStream] = event.streams;
       if (!trackStream) return;
       if (event.track.kind === "audio") {
-        this.remoteAudioStreams.set(connectionId, trackStream);
-        this.startRemoteSpeakingMonitor(connectionId, trackStream);
+        const audioTrack = event.track;
+        const existingStream = this.remoteAudioStreams.get(connectionId);
+        const aggregateStream = existingStream ?? new MediaStream();
+        const hadExistingStream = Boolean(existingStream);
+        if (!hadExistingStream) {
+          this.remoteAudioStreams.set(connectionId, aggregateStream);
+        }
+        const trackAlreadyAttached = aggregateStream
+          .getAudioTracks()
+          .some((existing) => existing.id === audioTrack.id);
+
+        if (!trackAlreadyAttached) {
+          try {
+            aggregateStream.addTrack(audioTrack);
+          } catch (err) {
+            if (import.meta.env.DEV) {
+              console.warn("Failed to attach remote audio track", err);
+            }
+            if (!hadExistingStream && aggregateStream.getAudioTracks().length === 0) {
+              this.remoteAudioStreams.delete(connectionId);
+            }
+            return;
+          }
+
+          let handleRemovetrack:
+            ((removeEvent: MediaStreamTrackEvent) => void) | null = null;
+
+          const handleTrackRemoval = () => {
+            audioTrack.removeEventListener("ended", handleTrackRemoval);
+            if (handleRemovetrack) {
+              trackStream.removeEventListener("removetrack", handleRemovetrack);
+              handleRemovetrack = null;
+            }
+            const remainingTracks = aggregateStream.getAudioTracks();
+            const stillPresent = remainingTracks.some(
+              (track) => track.id === audioTrack.id
+            );
+            if (stillPresent) {
+              try {
+                aggregateStream.removeTrack(audioTrack);
+              } catch (err) {
+                if (import.meta.env.DEV) {
+                  console.warn("Failed to detach remote audio track", err);
+                }
+              }
+            }
+            if (aggregateStream.getAudioTracks().length === 0) {
+              this.remoteAudioStreams.delete(connectionId);
+              this.stopRemoteSpeakingMonitor(connectionId);
+            } else {
+              this.startRemoteSpeakingMonitor(connectionId, aggregateStream);
+            }
+            this.emit();
+          };
+
+          handleRemovetrack = (removeEvent: MediaStreamTrackEvent) => {
+            if (removeEvent.track.id === audioTrack.id) {
+              handleTrackRemoval();
+            }
+          };
+
+          audioTrack.addEventListener("ended", handleTrackRemoval);
+          if (handleRemovetrack) {
+            trackStream.addEventListener("removetrack", handleRemovetrack);
+          }
+        }
+
+        this.startRemoteSpeakingMonitor(connectionId, aggregateStream);
         this.emit();
         return;
       }


### PR DESCRIPTION
This pull request introduces several improvements to the handling of screen audio tracks and remote audio streams in the voice channel logic. The main focus is on improving resource management, ensuring robust track replacement and detachment, and enhancing compatibility with transceivers. These changes help prevent audio issues, reduce errors, and improve the overall reliability of screen sharing and remote audio features.

**Screen audio management and resource cleanup:**

* Added a `screenAudioTransceivers` map to track transceivers for screen audio, and ensured proper cleanup of both senders and transceivers when connections are removed or reset. [[1]](diffhunk://#diff-23d5e2bc1a620ea098123cdde7dfa307f2f8edf541018d080652f85f44a081a6R93) [[2]](diffhunk://#diff-23d5e2bc1a620ea098123cdde7dfa307f2f8edf541018d080652f85f44a081a6R916) [[3]](diffhunk://#diff-23d5e2bc1a620ea098123cdde7dfa307f2f8edf541018d080652f85f44a081a6R969)
* Improved logic for replacing screen audio tracks: now attempts to use either an existing sender or a transceiver's sender, and falls back to creating a new sender if necessary. Also handles failed replacements and ensures senders are updated correctly. [[1]](diffhunk://#diff-23d5e2bc1a620ea098123cdde7dfa307f2f8edf541018d080652f85f44a081a6L1202-R1212) [[2]](diffhunk://#diff-23d5e2bc1a620ea098123cdde7dfa307f2f8edf541018d080652f85f44a081a6L1215-R1235) [[3]](diffhunk://#diff-23d5e2bc1a620ea098123cdde7dfa307f2f8edf541018d080652f85f44a081a6L1234-R1252)
* Enhanced detachment of screen audio senders by attempting both `replaceTrack(null)` and `removeTrack`, with better error handling and developer warnings for failed detachments.

**Transceiver support and connection setup:**

* When establishing a new peer connection, attempts to create and store a dedicated audio transceiver for screen audio if supported, improving compatibility and future handling of audio tracks.

**Remote audio stream aggregation and cleanup:**

* Improved handling of remote audio tracks by aggregating tracks into a single `MediaStream`, ensuring tracks are not duplicated, and adding robust cleanup for detached or ended tracks. Also manages speaking monitors and emits updates appropriately.

**Platform-specific audio capture:**

* On Windows, changed system audio capture to use `loopback` instead of `loopbackWithMute`, ensuring that capturing system audio does not mute the microphone stream.