### PR TITLE
Fix for share settings

### DIFF
--- a/client/src/app/shared/components/ScreenShareSettingsDialog.tsx
+++ b/client/src/app/shared/components/ScreenShareSettingsDialog.tsx
@@ -72,17 +72,26 @@ export default function ScreenShareSettingsDialog({
     return sources.find((source) => source.id === selectedSourceId) ?? null;
   }, [selectedSourceId, sources]);
 
-  useEffect(() => {
-    setResolutionId(getResolutionOptionForConstraints(initialConstraints).id);
-  }, [initialConstraints]);
+  const { width, height, frameRate, audio: initialAudioMode } =
+    initialConstraints;
 
   useEffect(() => {
-    setFrameRateId(getFrameRateOptionForConstraints(initialConstraints).id);
-  }, [initialConstraints]);
+    if (!open) return;
+    const nextId = getResolutionOptionForConstraints({ width, height }).id;
+    setResolutionId(nextId);
+  }, [height, open, width]);
 
   useEffect(() => {
-    setAudioId(getAudioOptionForConstraints(initialConstraints).id);
-  }, [initialConstraints]);
+    if (!open) return;
+    const nextId = getFrameRateOptionForConstraints({ frameRate }).id;
+    setFrameRateId(nextId);
+  }, [frameRate, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const nextId = getAudioOptionForConstraints({ audio: initialAudioMode }).id;
+    setAudioId(nextId);
+  }, [initialAudioMode, open]);
 
   useEffect(() => {
     if (!isDesktopRuntime) {
@@ -482,4 +491,3 @@ export default function ScreenShareSettingsDialog({
     </Dialog>
   );
 }
-


### PR DESCRIPTION
This pull request updates the state initialization logic for the `ScreenShareSettingsDialog` component to ensure that resolution, frame rate, and audio options are only set when the dialog is open. This helps prevent unnecessary state updates and potential inconsistencies when the dialog is not visible.

State initialization improvements:

* Updated the logic for setting `resolutionId`, `frameRateId`, and `audioId` so that these are only set when the dialog is open, using individual constraint values (`width`, `height`, `frameRate`, `audio`) rather than the entire `initialConstraints` object. This prevents unwanted state changes when the dialog is closed.

General cleanup:

* Removed an unnecessary trailing newline at the end of the file for consistency.…te, and audio mode based on initial constraints

Closes #142 