### PR TITLE
Fix message reply

### DIFF
--- a/client/src/app/shared/components/mediaChatComponent/chatMessageList/ChatMessageList.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/chatMessageList/ChatMessageList.tsx
@@ -398,12 +398,21 @@ export default function ChatMessageList(
                         textOverflow: "ellipsis",
                       }}
                     >
-                      {first.replyToType && first.replyToType !== "Text"
-                        ? `📎 ${
-                          first.replyToMediaOriginalFileName ||
-                          first.replyToType
-                        }`
-                        : first.replyToBody || ""}
+                      {(() => {
+                        const hasAttachment =
+                          !!first.replyToType && first.replyToType !== "Text";
+                        const trimmedBody = (first.replyToBody ?? "").trim();
+                        if (hasAttachment) {
+                          const fileName =
+                            (first.replyToMediaOriginalFileName ?? "").trim();
+                          return fileName.length > 0
+                            ? "[Attachment] " + fileName
+                            : "[Attachment] " + (first.replyToType ?? "Attachment");
+                        }
+                        return trimmedBody.length > 0
+                          ? trimmedBody
+                          : "Jump to original message";
+                      })()}
                     </Typography>
                   </Box>
                 )}

--- a/client/src/app/shared/components/mediaChatComponent/chatMessageList/ReplyPreview.tsx
+++ b/client/src/app/shared/components/mediaChatComponent/chatMessageList/ReplyPreview.tsx
@@ -17,25 +17,48 @@ export default function ReplyPreview({
   replyToType,
   replyToMediaOriginalFileName,
 }: Props) {
-  if (!replyToDisplayName && !replyToBody && !replyToType) return null;
+  const label = (replyToDisplayName?.trim() ?? "") || "message";
+  const hasAttachment = !!replyToType && replyToType !== "Text";
+  const trimmedBody = replyToBody?.trim() ?? "";
+
+  let description = "";
+  if (hasAttachment) {
+    const fileName = (replyToMediaOriginalFileName ?? "").trim();
+    description = fileName.length > 0
+      ? "[Attachment] " + fileName
+      : "[Attachment] " + (replyToType ?? "Attachment");
+  } else if (trimmedBody.length > 0) {
+    description = trimmedBody;
+  } else {
+    description = "Jump to original message";
+  }
+
   return (
     <Box
-      sx={{ mt: 0.25, pt: 0.25, borderTop: "1px solid", borderColor: "divider", cursor: onClick ? "pointer" : "default" }}
+      sx={{
+        mt: 0.25,
+        pt: 0.25,
+        borderTop: "1px solid",
+        borderColor: "divider",
+        cursor: onClick ? "pointer" : "default",
+      }}
       onClick={onClick}
     >
       <Typography variant="caption" sx={{ fontWeight: 700 }}>
-        Replying to {replyToDisplayName || "message"}
+        Replying to {label}
       </Typography>
       <Typography
         variant="caption"
         color={isOwn ? "inherit" : "text.secondary"}
-        sx={{ display: "block", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+        sx={{
+          display: "block",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
       >
-        {replyToType && replyToType !== "Text"
-          ? `📎 ${replyToMediaOriginalFileName || replyToType}`
-          : replyToBody || ""}
+        {description}
       </Typography>
     </Box>
   );
 }
-


### PR DESCRIPTION
Closes #155 

This pull request improves the handling and display of reply previews for messages, especially those with attachments, in the media chat component. The changes ensure that attachment replies are consistently labeled and fallback text is shown when necessary, enhancing clarity for users.

**Reply preview and attachment handling improvements:**

* Standardized the display logic for replies with attachments in both `ChatMessageList.tsx` and `ReplyPreview.tsx`, replacing the previous use of emoji and file/type fallback with a clear "[Attachment] filename" or "[Attachment] type" format. [[1]](diffhunk://#diff-74be728d84246c279a40316b1336c2ce58fc1326e42fbac483f6f7553198bf66L401-R415) [[2]](diffhunk://#diff-3700742774ffa84188f6b8e7a2d1f390d745382174df14fd83f8457d3928495eL20-L41)
* Added fallback text "Jump to original message" when neither attachment nor reply body is present, ensuring the UI always provides meaningful context. [[1]](diffhunk://#diff-74be728d84246c279a40316b1336c2ce58fc1326e42fbac483f6f7553198bf66L401-R415) [[2]](diffhunk://#diff-3700742774ffa84188f6b8e7a2d1f390d745382174df14fd83f8457d3928495eL20-L41)
* Improved trimming and fallback handling for display names and reply bodies, preventing display of empty or whitespace-only content.

These changes make reply previews more consistent and user-friendly, especially when dealing with attachments.