### PR TITLE
Production

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -45,6 +45,8 @@ jobs:
       # Build full installers (not just --dir)
       - name: Build Electron (${{ matrix.platform }})
         working-directory: client
+        env:
+          GH_TOKEN: ""
         run: npm run electron:package
 
       - name: Collect artifacts

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.0.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.0.0",
+      "version": "0.1.3",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^6.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "electron/main.js",
   "description": "RatChat desktop client for secure, realtime conversations with your team.",
@@ -80,6 +80,10 @@
     "vite": "^6.3.5",
     "vite-plugin-mkcert": "^1.17.8",
     "wait-on": "^9.0.1"
+  },
+  "scripts": {
+    "electron:build": "npm run build -- --base=./ && electron-builder --dir --publish=never",
+    "electron:package": "npm run build -- --base=./ && electron-builder --publish=never"
   },
   "build": {
     "appId": "com.ratchat.desktop",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.0",
   "type": "module",
   "main": "electron/main.js",
   "description": "RatChat desktop client for secure, realtime conversations with your team.",
@@ -81,10 +81,6 @@
     "vite-plugin-mkcert": "^1.17.8",
     "wait-on": "^9.0.1"
   },
-  "scripts": {
-    "electron:build": "npm run build -- --base=./ && electron-builder --dir --publish=never",
-    "electron:package": "npm run build -- --base=./ && electron-builder --publish=never"
-  },
   "build": {
     "appId": "com.ratchat.desktop",
     "productName": "RatChat",
@@ -100,7 +96,7 @@
     },
     "mac": {
       "category": "public.app-category.social-networking",
-      "artifactName": "RatChat-${version}.dmg",
+      "artifactName": "RatChat-${version}-mac.${ext}",
       "icon": "electron/resources/icon.icns"
     },
     "win": {
@@ -127,7 +123,7 @@
         "deb"
       ],
       "category": "Network",
-      "artifactName": "RatChat_${version}_${arch}.${ext}",
+      "artifactName": "RatChat-${version}.${ext}",
       "icon": "electron/resources/icon.png",
       "maintainer": "RatChat Team <jakkurc.dev@gmail.com>"
     }

--- a/client/src/features/download/DownloadPage.tsx
+++ b/client/src/features/download/DownloadPage.tsx
@@ -107,16 +107,22 @@ const releaseHistory: ReleaseEntry[] = [
 
 const latestVersion = releaseHistory[0]?.version ?? "0.0.0";
 
-const DOWNLOAD_RELEASE_TARGETS: Record<PlatformId, string> = {
-  windows: `RatChat-${latestVersion}-windows`,
-  mac: `RatChat-${latestVersion}-mac`,
-  linux: `RatChat-${latestVersion}-linux`,
+const DOWNLOAD_FILE_EXTENSIONS: Record<PlatformId, string> = {
+  windows: ".exe",
+  mac: ".dmg",
+  linux: ".deb",
+};
+
+const DOWNLOAD_RELEASE_FILENAMES: Record<PlatformId, string> = {
+  windows: `RatChat-${latestVersion}-windows${DOWNLOAD_FILE_EXTENSIONS.windows}`,
+  mac: `RatChat-${latestVersion}-mac${DOWNLOAD_FILE_EXTENSIONS.mac}`,
+  linux: `RatChat-${latestVersion}-linux${DOWNLOAD_FILE_EXTENSIONS.linux}`,
 };
 
 function buildReleaseUrl(platform: PlatformId) {
   const baseUrl = DOWNLOAD_URLS[platform];
   const normalizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
-  return `${normalizedBase}/releases/${DOWNLOAD_RELEASE_TARGETS[platform]}`;
+  return `${normalizedBase}/releases/${DOWNLOAD_RELEASE_FILENAMES[platform]}`;
 }
 
 const windowsExtras: DownloadExtra[] = [];
@@ -152,7 +158,7 @@ const downloadOptions: DownloadOption[] = [
     label: "Windows Installer",
     description: "Compatible with Windows 10 & 11 (x64)",
     icon: <LaptopWindows sx={{fontSize: 36}}/>,
-    filename: `RatChat-Setup-${latestVersion}.exe`,
+    filename: DOWNLOAD_RELEASE_FILENAMES.windows,
     url: buildReleaseUrl("windows"),
     size: "117 MB",
     footnote: "Supports auto-updates and background patching",
@@ -163,7 +169,7 @@ const downloadOptions: DownloadOption[] = [
     label: "macOS Universal DMG",
     description: "Works on Apple silicon & Intel Macs (13.0+)",
     icon: <LaptopMac sx={{fontSize: 36}}/>,
-    filename: `RatChat-${latestVersion}-mac.dmg`,
+    filename: DOWNLOAD_RELEASE_FILENAMES.mac,
     url: buildReleaseUrl("mac"),
     size: "124 MB",
     footnote: "Notarized and signed — drag & drop into Applications",
@@ -174,7 +180,7 @@ const downloadOptions: DownloadOption[] = [
     label: "Linux Builds",
     description: "AppImage + DEB packages (x64)",
     icon: <Terminal sx={{fontSize: 36}}/>,
-    filename: `RatChat-${latestVersion}.AppImage`,
+    filename: DOWNLOAD_RELEASE_FILENAMES.linux,
     url: buildReleaseUrl("linux"),
     size: "116 MB",
     footnote: "Make executable then run — integrates with most desktops",

--- a/client/src/features/download/DownloadPage.tsx
+++ b/client/src/features/download/DownloadPage.tsx
@@ -107,6 +107,18 @@ const releaseHistory: ReleaseEntry[] = [
 
 const latestVersion = releaseHistory[0]?.version ?? "0.0.0";
 
+const DOWNLOAD_RELEASE_TARGETS: Record<PlatformId, string> = {
+  windows: `RatChat-${latestVersion}-windows`,
+  mac: `RatChat-${latestVersion}-mac`,
+  linux: `RatChat-${latestVersion}-linux`,
+};
+
+function buildReleaseUrl(platform: PlatformId) {
+  const baseUrl = DOWNLOAD_URLS[platform];
+  const normalizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  return `${normalizedBase}/releases/${DOWNLOAD_RELEASE_TARGETS[platform]}`;
+}
+
 const windowsExtras: DownloadExtra[] = [];
 if (DOWNLOAD_EXTRA_URLS.windowsPortable) {
   windowsExtras.push({
@@ -141,7 +153,7 @@ const downloadOptions: DownloadOption[] = [
     description: "Compatible with Windows 10 & 11 (x64)",
     icon: <LaptopWindows sx={{fontSize: 36}}/>,
     filename: `RatChat-Setup-${latestVersion}.exe`,
-    url: DOWNLOAD_URLS.windows,
+    url: buildReleaseUrl("windows"),
     size: "117 MB",
     footnote: "Supports auto-updates and background patching",
     extras: windowsExtras.length ? windowsExtras : undefined,
@@ -152,7 +164,7 @@ const downloadOptions: DownloadOption[] = [
     description: "Works on Apple silicon & Intel Macs (13.0+)",
     icon: <LaptopMac sx={{fontSize: 36}}/>,
     filename: `RatChat-${latestVersion}-mac.dmg`,
-    url: DOWNLOAD_URLS.mac,
+    url: buildReleaseUrl("mac"),
     size: "124 MB",
     footnote: "Notarized and signed — drag & drop into Applications",
     extras: macExtras.length ? macExtras : undefined,
@@ -163,7 +175,7 @@ const downloadOptions: DownloadOption[] = [
     description: "AppImage + DEB packages (x64)",
     icon: <Terminal sx={{fontSize: 36}}/>,
     filename: `RatChat-${latestVersion}.AppImage`,
-    url: DOWNLOAD_URLS.linux,
+    url: buildReleaseUrl("linux"),
     size: "116 MB",
     footnote: "Make executable then run — integrates with most desktops",
     extras: linuxExtras.length ? linuxExtras : undefined,


### PR DESCRIPTION
This pull request standardizes the naming conventions for release artifacts across platforms and updates the download page logic to generate and display consistent filenames and URLs for installers. It also includes minor version updates and workflow adjustments.

**Release artifact naming and download logic:**

* Updated release artifact filenames in `client/package.json` for macOS and Linux to use a standardized format (`RatChat-${version}-mac.${ext}` and `RatChat-${version}.${ext}`), improving consistency across platforms. [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL99-R99) [[2]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL126-R126)
* Refactored download logic in `client/src/features/download/DownloadPage.tsx` to dynamically generate release filenames and URLs using the new conventions, ensuring the download page always matches the actual release artifacts. [[1]](diffhunk://#diff-9b38d25cb2dd9c0efcd7385ac0027d3dd194795858520e7fed8df821dc8c0b8bR110-R127) [[2]](diffhunk://#diff-9b38d25cb2dd9c0efcd7385ac0027d3dd194795858520e7fed8df821dc8c0b8bL143-R162) [[3]](diffhunk://#diff-9b38d25cb2dd9c0efcd7385ac0027d3dd194795858520e7fed8df821dc8c0b8bL154-R173) [[4]](diffhunk://#diff-9b38d25cb2dd9c0efcd7385ac0027d3dd194795858520e7fed8df821dc8c0b8bL165-R184)

**Version updates:**

* Updated the version in `client/package.json` and `client/package-lock.json` to reflect the latest release (`0.1.0` and `0.1.3` respectively). [[1]](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL4-R4) [[2]](diffhunk://#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3dL3-R9)

**Workflow adjustment:**

* Set an empty `GH_TOKEN` environment variable in the Electron build step of `.github/workflows/desktop_release.yml` to avoid authentication issues during CI builds.